### PR TITLE
Restricting Resource to one per team per type

### DIFF
--- a/board.js
+++ b/board.js
@@ -145,14 +145,24 @@ let gameBoard = {
                               {i: row-1, j: boardCenter+1, team: 'Green Team'},
                               {i: boardCenter+1, j: 0, team: 'Blue Team'}]
 
-
+        // function picks a tile form the resource deck and checks polayer does not already have this Resource allocated
         function completeAllocatedTile(locali, localj, localTeam) {
-            let deckCard = resourceManagement.pickFromResourceDeck();
+            stockDashboard.stockTake();
+            //keep for debugging -  console.log(stockDashboard.pieceTotals);
+
+            let pieceTotalsTeamPosition = stockDashboard.pieceTotals.findIndex(fI => fI.team == localTeam);
+            do {
+                var deckCard = resourceManagement.pickFromResourceDeck();
+                //keep for debugging - console.log(deckCard.type);
+            }
+            while (stockDashboard.pieceTotals[pieceTotalsTeamPosition].pieces[deckCard.type] > 0)
+
             gameBoard.boardArray[locali][localj].pieces = {populatedSquare: true, category: 'Resources', type: deckCard.type, direction: '0', used: 'unused', team: localTeam, goods: deckCard.goods, stock: 0};
         }
 
         for (var k = 0; k < allocateArray.length; k++) {
-           completeAllocatedTile(allocateArray[k].i, allocateArray[k].j, allocateArray[k].team)
+            //keep for debugging - console.log(k, allocateArray[k].team);
+            completeAllocatedTile(allocateArray[k].i, allocateArray[k].j, allocateArray[k].team)
         }
 
     },

--- a/dashboard.js
+++ b/dashboard.js
@@ -43,9 +43,9 @@ let stockDashboard = {
                     }
                 }
                 stockDashboard.pieceTotals[h].pieces[stockDashboard.pieceTypes[k].type] = counter;
-                //console.log(stockDashboard.pieceTotals[h].pieces[stockDashboard.pieceTypes[k].type]);
             }
         }
+          //console.log(stockDashboard.pieceTotals);
     },
 
     // Method to populate stock dashboard on left-hand panel

--- a/main.js
+++ b/main.js
@@ -275,11 +275,17 @@ boardMarkNode.addEventListener('click', function(event) {
         if (pieceMovement.movementArray[startEnd].pieces.populatedSquare) {
             // Claiming of unclaimed resources
             if (pieceMovement.movementArray[startEnd].pieces.category == 'Resources' && pieceMovement.movementArray[startEnd].pieces.type != 'desert' && pieceMovement.movementArray[startEnd].pieces.team == 'Unclaimed') {
-                if (pieceMovement.shipAvailable('crew') == 'crew') {
-                    // TO ADD - Check that ship has not previously landed crew somewhere
-                    commentary.innerHTML += ' <br>Click ship to land team and claim resource';
-                    startEnd = 'end';
-                    gameBoard.drawActiveTiles();
+                // Check that this resource type i snot already held by player
+                let pieceTotalsTeamPosition = stockDashboard.pieceTotals.findIndex(fI => fI.team == gameManagement.turn);
+                if(stockDashboard.pieceTotals[pieceTotalsTeamPosition].pieces[pieceMovement.movementArray.start.pieces.type] == 0) {
+                    if (pieceMovement.shipAvailable('crew') == 'crew') {
+                        // TO ADD - Check that ship has not previously landed crew somewhere
+                        commentary.innerHTML += ' <br>Click ship to land team and claim resource';
+                        startEnd = 'end';
+                        gameBoard.drawActiveTiles();
+                    }
+                } else {
+                    commentary.innerHTML += ' <br>You have already claimed your ' + pieceMovement.movementArray[startEnd].pieces.type;
                 }
             // Loading of a ship
           } else if (((pieceMovement.movementArray.start.pieces.category == 'Resources' && pieceMovement.movementArray.start.pieces.type != 'desert') || pieceMovement.movementArray.start.pieces.category == 'Settlements') && pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn) {


### PR DESCRIPTION
Resource tiles are now restricted to one per team.

This change aims to prevent teams stockpiling resources, to make the hunt for resources more interesting, and to add more strategy as to whether a team claims a particular resource or not considering its position on the board.

* Teams can no longer claim more than one of each resource type (main.js change)
* Initial allocation restricted to one of each Resource type (board.js change)