### PR TITLE
Adding trade routes

### DIFF
--- a/board.css
+++ b/board.css
@@ -24,6 +24,12 @@
     z-index: 2;
 }
 
+.tradeRoute {
+    position: absolute;
+    background-color: 'transparent';
+    z-index: 10;
+}
+
 /* style for row holders within game board */
 .board_row {
     margin: 0px 0px 0px 0px;

--- a/board.js
+++ b/board.js
@@ -137,12 +137,12 @@ let gameBoard = {
         // Creation of plantation
         this.boardArray[boardCenter][boardCenter+1].pieces = {populatedSquare: true, category: 'Resources', type: 'plantation', direction: '0', used: 'unused', team: 'Kingdom', goods: 'coffee', stock: 0};
 
-        /* // TEST AREA
-        this.boardArray[(row-3)][boardCenter].terrain = 'land';
-        this.boardArray[(row-3)][boardCenter].pieces = {populatedSquare: true, category: 'Settlements', type: 'fort', direction: '0', used: 'unused', team: 'Kingdom', goods: 'none', stock: 0};
-        tradeContracts.contractsArray[2].row = row-3;
-        tradeContracts.contractsArray[2].col = boardCenter;
-        */
+         // TEST AREA
+    /*  this.boardArray[(row-4)][boardCenter].terrain = 'land';
+        this.boardArray[(row-4)][boardCenter].pieces = {populatedSquare: true, category: 'Settlements', type: 'fort', direction: '0', used: 'unused', team: 'Kingdom', goods: 'none', stock: 0};
+        tradeContracts.contractsArray[2].row = row-4;
+        tradeContracts.contractsArray[2].col = boardCenter; */
+
     },
 
     // Method to allocate start tiles to teams
@@ -698,7 +698,6 @@ let gameBoard = {
             for (var j = 0; j < col; j++) {
                 Xcenter = (gridSize + tileBorder * 2) * j + (gridSize/2 + boardSurround + tileBorder);
 
-                // Currently just cargo ships - other tiles to be update to svg
                 if (this.boardArray[i][j].pieces.populatedSquare == true) {
                     // Create action tile svg and add to the board
                     boardMarkNode.appendChild(this.createActionTile(i, j, this.boardArray[i][j].pieces.type, this.boardArray[i][j].pieces.team,'tile' + Number(i*1000 + j), boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * i, boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * j, 1, this.boardArray[i][j].pieces.direction));
@@ -935,6 +934,63 @@ let gameBoard = {
         boardMarkNode.appendChild(compassLayer);
         boardMarkNode.appendChild(compassNeedleBox);
 
+
+    },
+
+    // Method to add trade route layer to board
+    // -----------------------------------------
+    createTradeRouteLayer: function() {
+        let layer = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        layer.setAttribute('width', col * (gridSize + tileBorder * 2) + boardSurround * 2);
+        layer.setAttribute('height', row * (gridSize + tileBorder * 2) + boardSurround * 2);
+        layer.setAttribute('viewBox', '0, 0, ' + (col * (gridSize + tileBorder * 2) + boardSurround * 2) +  ', ' + (row * (gridSize + tileBorder * 2) + boardSurround * 2));
+        layer.setAttribute('class', 'tradeRoute');
+        return(layer);
+    },
+
+    // Method to draw a trade route on the board
+    // -----------------------------------------
+    // Local path is an array of objects of the form {fromRow: 15, fromCol: 4}
+    tradeRoute: function(localPath, localTeam) {
+
+        let route = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        route.setAttribute('class', localTeam + ' team_route');
+
+        let buildRoute = 'M ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromCol) + ' ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromRow);
+        //let buildRoute = 'M ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromCol + gameManagement.teamArray.indexOf(gameManagement.turn)*2-4) + ' ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromRow + gameManagement.teamArray.indexOf(gameManagement.turn)*2-4);
+
+        for (var i = 0; i < localPath.length; i++) {
+            buildRoute += ' L ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[i].fromCol) + ' ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[i].fromRow);
+            //buildRoute += ' L ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[i].fromCol + gameManagement.teamArray.indexOf(gameManagement.turn)*2-4) + ' ' + (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[i].fromRow + gameManagement.teamArray.indexOf(gameManagement.turn)*2-4);
+        }
+
+        route.setAttribute('d', buildRoute);
+        route.setAttribute('fill', 'none');
+        route.setAttribute('stroke-linecap', 'round');
+        route.setAttribute('stroke-linejoin', 'round');
+        route.setAttribute('stroke-opacity', '0.5');
+        route.style.strokeWidth = '3px';
+        tradeRouteLayer.appendChild(route);
+
+        let startCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        startCircle.setAttribute('class', localTeam + ' team_fill team_route');
+        startCircle.setAttribute('cx', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromCol));
+        startCircle.setAttribute('cy', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[0].fromRow));
+        startCircle.setAttribute('r', '3');
+        startCircle.style.strokeWidth = '1px';
+        startCircle.style.strokeLinecap = 'round';
+        startCircle.setAttribute('fill', 'none');
+        tradeRouteLayer.appendChild(startCircle);
+
+        let endCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        endCircle.setAttribute('class', localTeam + ' team_fill team_route');
+        endCircle.setAttribute('cx', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[localPath.length-1].fromCol));
+        endCircle.setAttribute('cy', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * localPath[localPath.length-1].fromRow));
+        endCircle.setAttribute('r', '3');
+        endCircle.style.strokeWidth = '1px';
+        endCircle.style.strokeLinecap = 'round';
+        //endCircle.setAttribute('fill', 'none');
+        tradeRouteLayer.appendChild(endCircle);
 
     },
 

--- a/compass.css
+++ b/compass.css
@@ -7,7 +7,6 @@
     position: absolute;
     background-color: rgb(246, 232, 206);
     z-index: 1;
-
 }
 
 #needle2 {

--- a/contracts.js
+++ b/contracts.js
@@ -9,7 +9,6 @@ let tradeContracts = {
                       {name: 'Swordfish'},
                     ],
 
-
     // Method to populate contracts array
     // ----------------------------------
     populateContracts: function() {
@@ -70,8 +69,8 @@ let tradeContracts = {
     },
 
 
-// Method to check possible delivery to fulfil open contract
-// ---------------------------------------------------------
+    // Method to check possible delivery to fulfil open contract
+    // ---------------------------------------------------------
     checkDelivery : function(locali, localj, searchType, localStock) {
         // Determines which fort is being delivered to
         let chosenFort = -1;
@@ -92,36 +91,279 @@ let tradeContracts = {
 
     // Method to complete contract delivery
     // ------------------------------------
-        fulfilDelivery : function() {
-            // Determines which fort is being delivered to
-            let chosenFort = -1;
-            for (var k = 0; k < this.contractsArray.length; k++) {
-                if(this.contractsArray[k].row == pieceMovement.movementArray.end.row && this.contractsArray[k].col == pieceMovement.movementArray.end.col) {
-                    chosenFort = k;
+    fulfilDelivery : function() {
+        // Determines which fort is being delivered to
+        let chosenFort = -1;
+        for (var k = 0; k < this.contractsArray.length; k++) {
+            if(this.contractsArray[k].row == pieceMovement.movementArray.end.row && this.contractsArray[k].col == pieceMovement.movementArray.end.col) {
+                chosenFort = k;
+            }
+        }
+
+        // Updates game board based on delivery
+        deliveryGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
+        deliveryStock = this.contractsArray[chosenFort].contracts[deliveryGoods].initial;
+        gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= deliveryStock;
+        if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock == 0) {
+            gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods = 'none';
+        }
+
+        // Updates contracts array based on delivery
+        this.contractsArray[chosenFort].contracts[deliveryGoods].struck = gameManagement.turn;
+        this.contractsArray[chosenFort].totalOpen -=1;
+        this.contractsArray[chosenFort].totalClosed +=1;
+    },
+
+    // Array of paths for finding trade route
+    // --------------------------------------
+    tradePath: [],
+
+    // Method to initialise tradePath array which holds board size (i rows x j columns) array of paths
+    // -----------------------------------------------------------------------------------------------
+    initialiseTradePath: function(localStartRow, localStartCol) {
+        for (var i = 0; i < col; i++) {
+            let localMoveRow = [];
+            for (var j = 0; j < row; j++) {
+                localMoveRow[j] = {activeStatus: 'inactive', moveCost: 0, distance: 0, team: '', path: [{fromRow: +localStartRow , fromCol: +localStartCol}]};
+            }
+            this.tradePath[i] = localMoveRow;
+        }
+    },
+
+    // Method to find path for ship to move
+    // ------------------------------------
+    discoverPath: function(localEndRow, localEndCol, localGoods) {
+        // Finds current team resource in boardArray for start of path
+        let localStartRow = 0;
+        let localStartCol = 0;
+        for (var y = 0; y < gameBoard.boardArray.length; y++) {
+            for (var x = 0; x < gameBoard.boardArray[y].length; x++) {
+                if (gameBoard.boardArray[y][x].pieces.team == gameManagement.turn && gameBoard.boardArray[y][x].pieces.goods == localGoods && gameBoard.boardArray[y][x].pieces.category == 'Resources') {
+                    localStartRow = y;
+                    localStartCol = x;
                 }
             }
+        }
 
-            // Updates game board based on delivery
-            deliveryGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
-            deliveryStock = this.contractsArray[chosenFort].contracts[deliveryGoods].initial;
-            gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= deliveryStock;
-            if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock == 0) {
-                gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods = 'none';
+        // Converts start and end land positions into the nearest non-diagonal sea positions for start and end of trade route
+        let harbour = this.nearestHarbour(localStartRow, localStartCol, localEndRow, localEndCol);
+
+        // Finds straight-line direction from start to end of trade path to aid in choice of trade path route
+        let directionAngle = Math.floor(Math.atan(Math.abs(harbour.harbourEndCol - harbour.harbourStartCol) / Math.abs(harbour.harbourEndRow - harbour.harbourStartRow)) * (180 / Math.PI));
+        if(harbour.harbourEndRow - harbour.harbourStartRow > 0 && harbour.harbourEndCol - harbour.harbourStartCol > 0) {
+            directionAngle += 90;
+        } else if(harbour.harbourEndRow - harbour.harbourStartRow > 0 && harbour.harbourEndCol - harbour.harbourStartCol <= 0) {
+            directionAngle -= 180;
+        } else if(harbour.harbourEndRow - harbour.harbourStartRow <= 0 && harbour.harbourEndCol - harbour.harbourStartCol <= 0) {
+            directionAngle -= 90;
+        }
+
+        // Safety net on number of iterations - should not be required as while loop applied
+        let localMaxMove = Math.abs(localEndRow - localStartRow) + Math.abs(localEndCol - localStartCol);
+
+        // Initialises tradePath array which holds board size array of paths
+        this.initialiseTradePath(harbour.harbourStartRow, harbour.harbourStartCol);
+
+        // Sets clicked piece status to active as starting point of chain reaction of setting active status
+        this.tradePath[harbour.harbourStartRow][harbour.harbourStartCol].activeStatus = 'active';
+
+        // Loops until fort destination harbour is found
+        // Each loop searches for potentially reachable tiles to activated within one tile reach of a previously activated tile
+        // First search (k=0) takes each active tile within 1x1 grid around piece (i.e. just the piece itself) then uses
+        // pathTiles to search in 3x3 grid around this tile
+        // Second search (k=1) takes each active tile within a 3x3 grid of the piece (i.e. within one tile move reach of the piece) then uses
+        // pathTiles to search in 3x3 grid around each of these active tiles
+        // Third search (k=2) takes each active tile within a 5x5 grid of the piece (i.e. within two tile move reach of the piece) then uses
+        // pathTiles to search in 3x3 grid around each of these active tiles (making a maximum potential 3 tile distance  from the piece for active tiles)
+        // Continues until destination is found
+
+        let k = 0;
+        let found = false;
+        while (found == false && k < localMaxMove) {
+
+            // Loops through i rows and j columns to form the 3x3 etc grids
+            for (var i = -k; i < k+1; i++) {
+                // Restrict by map size for rows so not searching off edge of board
+                if(harbour.harbourStartRow+i>=0 && harbour.harbourStartRow+i <row) {
+                    for (var j = -k; j < k+1; j++) {
+                        // Restrict by map size for columns so not searching off edge of board
+                        if(harbour.harbourStartCol+j >=0 && harbour.harbourStartCol+j <col) {
+                            // Checks if tile is active. If so runs pathTiles to search for potential tiles to activate around it
+                            if (this.tradePath[harbour.harbourStartRow+i][harbour.harbourStartCol+j].activeStatus == 'active') {
+                                //keep for debugging - console.log('run: ' + k);
+                                //keep for debugging - console.log('starting from: row: ' + (localStartRow+i) + ' col: ' + (localStartCol+j) + ' prior cost: ' + this.tradePath[localStartRow+i][localStartCol+j].moveCost);
+                                searchFound = this.pathTiles(harbour.harbourStartRow+i, harbour.harbourStartCol+j, this.tradePath[harbour.harbourStartRow+i][harbour.harbourStartCol+j].moveCost, localMaxMove, directionAngle, k, harbour.harbourEndRow, harbour.harbourEndCol);
+                                if (searchFound == true) {
+                                    found = true;
+
+                                }
+                            }
+                        }
+                    }
+                }
             }
+            k += 1;
+        }
+        // creates the SVG path for the trade route
+        let localPath = this.tradePath[harbour.harbourEndRow][harbour.harbourEndCol].path;
+        gameBoard.tradeRoute(localPath, gameManagement.turn);
+    },
 
-            // Updates contracts array based on delivery
-            this.contractsArray[chosenFort].contracts[deliveryGoods].struck = gameManagement.turn;
-            this.contractsArray[chosenFort].totalOpen -=1;
-            this.contractsArray[chosenFort].totalClosed +=1;
+    // Method to seacrh for route around obstacles
+    // -------------------------------------------
+    pathTiles: function(localStartRowI, localStartColJ, localCumulMoveCost, localMaxMove, directionAngle, k, localEndRow, localEndCol) {
+        // pathTiles searches a 3x3 grid around the passed (activated) tile reference to find more potential tiles to activate
+        // Restrictions on activation are: board size and land
+        // If a second path arrives at an already activated tile with a cheaper cost this path replaces the existing findPath
 
-        },
+        // Initialise local variable for cumulative cost of reaching tile and found boolean for confirmation of destination
+        let tileCumulMoveCost = 0;
+        let localFound = false;
 
+        // Loop through rows
+        for (var i = -1; i <= 1; i++) {
+            // Restrict by map size for rows
+            if(localStartRowI+i>=0 && localStartRowI+i <row) {
+                // Loop through columns
+                for (var j = -1; j <= 1; j++) {
+                    // Restrict by map size for columns
+                    if(localStartColJ+j >=0 && localStartColJ+j <col) {
+                        // Restrict for land squares
+                        if (gameBoard.boardArray[localStartRowI+i][localStartColJ+j].terrain == 'sea' || (localStartRowI+i == localEndRow && localStartColJ+j == localEndCol)) {
+                            // Checks for reaching destination
+                            if (localStartRowI+i == localEndRow && localStartColJ+j == localEndCol) {
+                                localFound = true;
+                            }
+                            // Aggregate cost of reaching tile in tileCumulMoveCost - add the existing cost to the cost for reaching the new tile from moveCost
+                            tileCumulMoveCost = localCumulMoveCost + this.pathCost(localStartRowI, localStartColJ ,localStartRowI+i, localStartColJ+j, directionAngle);
 
+                            // Logic for already active tiles - is the new path cheaper in pathCost?
+                            if (this.tradePath[localStartRowI+i][localStartColJ+j].activeStatus == 'active') {
+                                if (tileCumulMoveCost < this.tradePath[localStartRowI+i][localStartColJ+j].moveCost) {
+                                    // Keep useful for debugging - console.log('already active logic is used:');
+                                    // Keep useful for debugging - console.log('change to active tile - pre:', localStartRowI+i, localStartColJ+j, this.tradePath[localStartRowI+i][localStartColJ+j], localStartRowI, localStartColJ, this.tradePath[localStartRowI][localStartColJ]);
+                                    // Update the cost, add the inherited path from the previous moved-to tile, push the path for the new tile
+                                    this.tradePath[localStartRowI+i][localStartColJ+j].moveCost = tileCumulMoveCost;
+                                    this.tradePath[localStartRowI+i][localStartColJ+j].path = this.tradePath[localStartRowI][localStartColJ].path.slice(0);
+                                    this.tradePath[localStartRowI+i][localStartColJ+j].path.push({fromRow: +(localStartRowI+i) , fromCol: +(localStartColJ+j)});
+                                    this.tradePath[localStartRowI+i][localStartColJ+j].distance = this.tradePath[localStartRowI+i][localStartColJ+j].path.length-1;
+                                    // Keep useful for debugging - console.log('change to active tile - post:', localStartRow+i, localStartCol+j, this.findPath[localStartRow+i][localStartCol+j], localStartRow, localStartCol, this.findPath[localStartRow][localStartCol]);
+                                }
+                            // Logic for inactive tiles that have met all criteria - activate them!
+                            } else if (this.tradePath[localStartRowI+i][localStartColJ+j].activeStatus != 'active') {
+                                // Keep useful for debugging - console.log('new pre-activation:', localStartRow+i, localStartCol+j, this.findPath[localStartRow+i][localStartCol+j], localStartRow, localStartCol, this.findPath[localStartRow][localStartCol]);
+                                this.tradePath[localStartRowI+i][localStartColJ+j].activeStatus = 'active';
+                                // Update the cost, add the inherited path from the previous moved-to tile, push the path for the new tile
+                                this.tradePath[localStartRowI+i][localStartColJ+j].moveCost = tileCumulMoveCost;
+                                this.tradePath[localStartRowI+i][localStartColJ+j].path = this.tradePath[localStartRowI][localStartColJ].path.slice(0);
+                                this.tradePath[localStartRowI+i][localStartColJ+j].path.push({fromRow: +(localStartRowI+i) , fromCol: +(localStartColJ+j)});
+                                this.tradePath[localStartRowI+i][localStartColJ+j].distance = this.tradePath[localStartRowI+i][localStartColJ+j].path.length-1;
+                                //Keep useful for debugging - console.log('new post-activation:', localStartRow+i, localStartCol+j, this.findPath[localStartRow+i][localStartCol+j], localStartRow, localStartCol, this.findPath[localStartRow][localStartCol]);
+                                //Keep useful for debugging - console.log('row: ' + (localStartRow+i) + ' col: ' + (localStartCol+j) + ' set to: ' + this.findPath[localStartRow+i][localStartCol+j].activeStatus + ' with cost: ' + this.findPath[localStartRow+i][localStartCol+j].moveCost + ' and distance: ' + this.findPath[localStartRow+i][localStartCol+j].distance);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return localFound;
+    },
+
+    // Method to find nearest harbour to destination
+    // ---------------------------------------------
+    // Converts start and end land positions into the nearest non-diagonal sea positions for start and end of trade route
+    nearestHarbour: function(localStartRow, localStartCol, localEndRow, localEndCol) {
+        let harbourRank = [];
+        let vertical = localEndRow - localStartRow;
+        let horizontal = localEndCol - localStartCol;
+        // Ranks the possible adjacent tiles in order of preference according to the direction of the trade route
+        if(Math.abs(vertical) > Math.abs(horizontal)) {
+            if(vertical >= 0) {
+                if(horizontal >= 0) {
+                    harbourRank = [[1,0], [0,1], [0,-1], [-1,0]]
+                } else {
+                    harbourRank = [[1,0], [0,-1], [0,1], [-1,0]]
+                }
+            } else {
+                if(horizontal >= 0) {
+                    harbourRank = [[-1,0], [0,1], [0,-1], [1,0]]
+                } else {
+                    harbourRank = [[-1,0], [0,-1], [0,1], [1,0]]
+                }
+            }
+        } else {
+            if(vertical >= 0) {
+                if(horizontal >= 0) {
+                    harbourRank = [[0,1], [1,0], [-1,0], [0,-1]]
+                } else {
+                    harbourRank = [[0,-1], [1,0], [-1,0], [0,1]]
+                }
+            } else {
+                if(horizontal >= 0) {
+                    harbourRank = [[0,1], [-1,0], [1,0], [0,-1]]
+                } else {
+                    harbourRank = [[0,-1], [-1,0], [1,0], [0,1]]
+                }
+            }
+        }
+
+        let resourceHarbour = false;
+        let fortHarbour = false;
+        let harbourStartRow = 0;
+        let harbourStartCol = 0;
+        let harbourEndRow = 0;
+        let harbourEndCol = 0;
+
+        // Loops through each of four possible tiles to find preferred harbour
+        for (var i = 0; i < harbourRank.length; i++) {
+
+            if(resourceHarbour == false && (localStartRow+harbourRank[i][0]) >=0 && (localStartRow+harbourRank[i][0]) < 31 && (localStartCol+harbourRank[i][1]) >=0 && (localStartCol+harbourRank[i][1]) < 31) {
+
+                if(gameBoard.boardArray[localStartRow+harbourRank[i][0]][localStartCol+harbourRank[i][1]].terrain == 'sea') {
+                    harbourStartRow = localStartRow+harbourRank[i][0];
+                    harbourStartCol = localStartCol+harbourRank[i][1];
+                    resourceHarbour = true;
+                }
+            }
+            // Reverses the order of preference at the other end of the trade route
+            if(fortHarbour == false && (localEndRow+harbourRank[harbourRank.length - 1 - i][0]) >=0 && (localEndRow+harbourRank[harbourRank.length - 1 - i][0]) < 31 && (localEndCol+harbourRank[harbourRank.length - 1 - i][1]) >=0 && (localEndCol+harbourRank[harbourRank.length - 1 - i][1]) < 31) {
+
+                if(gameBoard.boardArray[localEndRow+harbourRank[harbourRank.length - 1 - i][0]][localEndCol+harbourRank[harbourRank.length - 1 - i][1]].terrain == 'sea') {
+                    harbourEndRow = localEndRow+harbourRank[harbourRank.length - 1 - i][0];
+                    harbourEndCol = localEndCol+harbourRank[harbourRank.length - 1 - i][1];
+                    fortHarbour = true;
+                }
+            }
+        }
+        return {harbourStartRow, harbourStartCol, harbourEndRow, harbourEndCol};
+    },
+
+    // Method to find the most direct trade route
+    // -------------------------------------------
+    // Sets the cost of each move in relation to the overall direction of the trade route
+    pathCost: function(localStartRow, localStartCol, localEndRow, localEndCol, localDirectionAngle) {
+        let moveCostResult = 0;
+        // Calculates direction of move
+        let localMoveTop = (localEndRow - localStartRow);
+        let localMoveLeft = (localEndCol - localStartCol);
+        let localMoveDirection = pieceMovement.movementDirection[localMoveLeft+1][localMoveTop+1];
+        // Calculates difference in angle of direction between trade route direction and piece movement
+        let angleDiff = (localMoveDirection - localDirectionAngle + 360) % 360;
+        // Returns cost based on the difference in angle
+        if (angleDiff > 89 && angleDiff < 271) {
+            moveCostResult = 1.1;
+        } else if (angleDiff > 44 && angleDiff < 316) {
+            moveCostResult = 0.9;
+        } else {
+            moveCostResult = 0.75;
+        }
+        return moveCostResult;
+    },
 
 // Method to populate contract dashboard on right-hand panel
 // ---------------------------------------------------------
 
-    drawContracts : function() {
+    drawContracts: function() {
         // Finds the stockDashboard holder in the left hand panel
         let contractDashboardNode = document.querySelector('div.contractDashboard');
 

--- a/main.js
+++ b/main.js
@@ -39,7 +39,6 @@ for (var c = 0; c < headFootCollection.length; c++) {
 // boardMarkNode is board holder in document
 let boardMarkNode = document.querySelector('div.boardmark');
 
-
 // Canvas element createed for board
 let board = document.createElement('canvas');
 board.setAttribute('id', 'board');
@@ -49,7 +48,6 @@ let canvasBoard = board.getContext('2d');
 canvasBoard.canvas.width = col * (gridSize + tileBorder * 2) + boardSurround * 2;
 canvasBoard.canvas.height = row * (gridSize + tileBorder * 2) + boardSurround * 2;
 
-
 // Canavs 'activeBoard' is created and size is set dynamically
 let activeBoard = document.createElement('canvas');
 boardMarkNode.appendChild(activeBoard);
@@ -58,6 +56,10 @@ canvasActive.canvas.width = row * (gridSize + tileBorder * 2) + boardSurround * 
 canvasActive.canvas.height = col * (gridSize + tileBorder * 2) + boardSurround * 2;
 // ID is set with CSS styles of higher z-index and transparent background to function as overlay
 activeBoard.setAttribute('id', 'activeBoard');
+
+// SVG layer for trade routes set up
+let tradeRouteLayer = gameBoard.createTradeRouteLayer();
+boardMarkNode.appendChild(tradeRouteLayer);
 
 // Function to set up board and resource deck and allocate resources
 function boardSetUp(row, col, gridSize, boardShape) {
@@ -238,7 +240,7 @@ window.addEventListener('click', function(element) {
 // Maximum number of iterations for movement and thus maximum number of tiles that can be moved
 // --- movement is also influenced by the movement cost
 // --- once more transport is created this will all need to be built into an array if it desired that different ships move at different speeds
-let maxMove = 3;
+let maxMove = 5;
 
 // Variables for clicked tiles with startEnd indicating the start or end of the move
 let startEnd = 'start';
@@ -388,6 +390,7 @@ boardMarkNode.addEventListener('click', function(event) {
                 gameBoard.drawActiveTiles();
                 tradeContracts.fulfilDelivery();
                 tradeContracts.drawContracts();
+                tradeContracts.discoverPath(pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
 
             // Unloading to own team fort or resource tile
             } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == gameManagement.turn && (pieceMovement.movementArray.end.pieces.type == 'fort' || pieceMovement.movementArray.end.pieces.category == 'Resources')) {

--- a/movement.js
+++ b/movement.js
@@ -252,6 +252,10 @@ let pieceMovement = {
 
         // Obtaining path of piece that leads to end tile of move from findPath array
         let localPath = this.findPath[this.movementArray.end.row][this.movementArray.end.col].path;
+        console.log(localPath);
+        // tem p
+        //gameBoard.tradeRoute(localPath, gameManagement.turn);
+
         // Length gives number of steps in path
         let numberOfTiles = localPath.length - 1;
 
@@ -302,6 +306,7 @@ let pieceMovement = {
             chosenPiece.style.top = parseFloat(chosenPiece.style.top) + (topDirection * (gridSize + tileBorder*2)) + 'px';
             chosenPiece.style.transform = 'rotate(' + rotateDirection + 'deg)';
         }, n * 1000);
+
     },
 
     // Method to allow discovery of new land tiles

--- a/pieces.css
+++ b/pieces.css
@@ -370,6 +370,10 @@
     stroke: #00394d;
 }
 
+.Blue.team_route {
+    stroke: #0099cc;
+}
+
 
 .Orange.team_fill  {
     background-color: #bd5d0f;
@@ -378,6 +382,10 @@
 
 .Orange.team_stroke {
     stroke: #472306;
+}
+
+.Orange.team_route {
+    stroke: #bd5d0f;
 }
 
 .Red.team_fill {
@@ -389,6 +397,10 @@
     stroke: #3e0f1a;
 }
 
+.Red.team_route {
+    stroke: #a52746;
+}
+
 .Green.team_fill {
     background-color: #34987d;
     fill: #34987d;
@@ -396,6 +408,10 @@
 
 .Green.team_stroke {
     stroke: #14392f;
+}
+
+.Green.team_route {
+    stroke: #34987d;
 }
 
 .Kingdom.team_stroke {


### PR DESCRIPTION
* Trade route SVG board layer added (createTradeRouteLayer)
* Method (tradeRoute) added to draw an SVG path in team colours based on an array of tile coordinates
* Circle end points added for each end of SVG trade route path
* Method (initialiseTradePath) to initialise tradePath array which holds board size (i rows x j columns) array of paths
* Method (nearestHarbour) added which finds best sea harbour tiles next to Resource and Fort start and end points.
* Methods (discoverPath, pathTiles, pathCost) added which find most direct trade route between two points, avoiding islands.
* Trade route creation added to game flow logic.