### PR TITLE
Addition of safe harbour functionality

### DIFF
--- a/board.js
+++ b/board.js
@@ -19,10 +19,10 @@ let gameBoard = {
             for (var x = 0; x < row; x++) {
                 // A few random land tiles
                 if(Math.random() > 0.995) {
-                    rowArray.push({xpos: + x, ypos: + y, terrain: 'land', activeStatus: 'inactive', pieces: {populatedSquare: false, category: '', type: 'no piece', direction: '', used: 'unused', damageStatus: 'good', team: '', goods: 'none', stock: 0}});
+                    rowArray.push({xpos: + x, ypos: + y, terrain: 'land', subTerrain: 'none', activeStatus: 'inactive', pieces: {populatedSquare: false, category: '', type: 'no piece', direction: '', used: 'unused', damageStatus: 'good', team: '', goods: 'none', stock: 0}});
                 // But mainly sea tiles
                 } else {
-                    rowArray.push({xpos: + x, ypos: + y, terrain: 'sea', activeStatus: 'inactive', pieces: {populatedSquare: false, category: '', type: 'no piece', direction: '', used: 'unused', damageStatus: 'good', team: '', goods: 'none', stock: 0}});
+                    rowArray.push({xpos: + x, ypos: + y, terrain: 'sea', subTerrain: 'none', activeStatus: 'inactive', pieces: {populatedSquare: false, category: '', type: 'no piece', direction: '', used: 'unused', damageStatus: 'good', team: '', goods: 'none', stock: 0}});
                 }
             }
         this.boardArray.push(rowArray);
@@ -929,7 +929,9 @@ let gameBoard = {
         for (var h = 0; h < octagonArray.length; h++) {
             this.drawTiles (octagonArray[h].type, canvasBoard, octagonArray[h].gap, octagonArray[h].width, octagonArray[h].colour, octagonArray[h].background)
         }
+        this.drawSafeHarbours();
         this.drawCompass();
+
     },
 
     // New method to create the board pieces based on the boardArray using SVG
@@ -966,7 +968,10 @@ let gameBoard = {
                     // Tiles - 'invis' gives shape to octagonal board
                     this.drawOctagon(boardLayer, ocatagonGap);
                 } else if (octagonType=='active' && this.boardArray[i][j].activeStatus == 'active') {
-                    // Activation of tiles - will be moved to a separate canvas overlay in future
+                    // Activation of tiles - on a separate canvas overlay
+                    this.drawOctagon(boardLayer, ocatagonGap);
+                } else if (octagonType=='harbour' && this.boardArray[i][j].subTerrain == 'harbour') {
+                    // Draws safe harbours - on a separate canvas overlay
                     this.drawOctagon(boardLayer, ocatagonGap);
                 } else if (octagonType=='land' && this.boardArray[i][j].terrain == 'land') {
                     // Islands
@@ -986,7 +991,6 @@ let gameBoard = {
 
     // Method to set up canvas overlay layer for piece activation
     // ----------------------------------------------------------
-
     drawActiveTiles: function () {
         // Clears the canvas for redraw
         canvasActive.clearRect(0, 0, canvasActive.canvas.width, canvasActive.canvas.height);
@@ -994,6 +998,15 @@ let gameBoard = {
         // drawTiles is used to colour tiles on active layer
         gameBoard.drawTiles ('active', canvasActive, 0, 1, 'rgb(255, 153, 153)', 'transparent');
 
+        // safe harbours are also drawn on canvasActive later - can be changed later if necessary
+        this.drawSafeHarbours();
+    },
+
+    // Method to add safe harbours to the map
+    // --------------------------------------
+    drawSafeHarbours: function () {
+        // safe harbours are also drawn on canvasActive later - can be changed later if necessary
+        gameBoard.drawTiles ('harbour', canvasActive, 0, 1, 'transparent', 'rgb(233, 211, 183)');
     },
 
     // Method to draw octagons for creation of board

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ let canvasBoard = board.getContext('2d');
 canvasBoard.canvas.width = col * (gridSize + tileBorder * 2) + boardSurround * 2;
 canvasBoard.canvas.height = row * (gridSize + tileBorder * 2) + boardSurround * 2;
 
-// Canavs 'activeBoard' is created and size is set dynamically
+// Canvas 'activeBoard' (for active tiles that can be moved to) is created and size is set dynamically
 let activeBoard = document.createElement('canvas');
 boardMarkNode.appendChild(activeBoard);
 let canvasActive = activeBoard.getContext('2d');
@@ -65,6 +65,7 @@ boardMarkNode.appendChild(tradeRouteLayer);
 function boardSetUp(row, col, gridSize, boardShape) {
     gameBoard.populateBoardArray(row, col, boardShape);
     gameBoard.overlayBoardArray(row, col, boardShape);
+    pirates.safeHarbour();
 
     // Set up of resources
     resourceManagement.populateResourceDeck();

--- a/movement.js
+++ b/movement.js
@@ -104,11 +104,12 @@ let pieceMovement = {
                         // Restrict for land squares ( ---- and objects ---- )
                         // if (gameBoard.boardArray[localStartRow+i][localStartCol+j].terrain == 'sea' && gameBoard.boardArray[localStartRow+i][localStartCol+j].pieces.populatedSquare == false) {
                         if (gameBoard.boardArray[localStartRow+i][localStartCol+j].terrain == 'sea') {
-                            // Aggregate cost of reaching tile in tileCumulMoveCost - add the exiting cost to the cost for reaching the new tile from moveCost
-                            //console.log('row: ' + (localStartRow+i) + ' col: ' + (localStartCol+j) + ' prior cost: ' + localCumulMoveCost + ' new cost: ' + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection))
-                            tileCumulMoveCost = localCumulMoveCost + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection);
-                            // Restrict activation by Maximum Cost of reaching a tile (allows wind direction to be factored in to move)
-                            //if (tileCumulMoveCost <= localMaxMove) {
+                            if (!((gameBoard.boardArray[localStartRow+i][localStartCol+j].subTerrain == 'harbour') && (gameManagement.turn == 'Pirate')) ) {
+                                // Aggregate cost of reaching tile in tileCumulMoveCost - add the exiting cost to the cost for reaching the new tile from moveCost
+                                //console.log('row: ' + (localStartRow+i) + ' col: ' + (localStartCol+j) + ' prior cost: ' + localCumulMoveCost + ' new cost: ' + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection))
+                                tileCumulMoveCost = localCumulMoveCost + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection);
+                                // Restrict activation by Maximum Cost of reaching a tile (allows wind direction to be factored in to move)
+                                //if (tileCumulMoveCost <= localMaxMove) {
                                 // Separate newly found tiles from previously found tiles
                                 if (this.findPath[localStartRow+i][localStartCol+j].pathStatus == true) {
                                     // Logic for already active tiles - is the new path cheaper in moveCost?
@@ -173,9 +174,8 @@ let pieceMovement = {
 
                                     //console.log(this.findPath[localStartRow+i][localStartCol+j]);
                                 }
-
-
                             //}
+                            }
                         }
                     }
                 }

--- a/pirates.js
+++ b/pirates.js
@@ -138,7 +138,7 @@ let pirates = {
         this.targetTelescope = [];
         for (var i = 0; i < col; i++) {
             for (var j = 0; j < row; j++) {
-                if ((pieceMovement.findPath[i][j].target == 'cargo ship') && (gameBoard.boardArray[i][j].pieces.team != 'Pirate') && (gameBoard.boardArray[i][j].pieces.damageStatus != 'damaged')) {
+                if ((pieceMovement.findPath[i][j].target == 'cargo ship') && (gameBoard.boardArray[i][j].pieces.team != 'Pirate') && (gameBoard.boardArray[i][j].pieces.damageStatus != 'damaged') && (gameBoard.boardArray[i][j].subTerrain != 'harbour')) {
                     this.targetTelescope.push({row: + i, col: + j, distance: + pieceMovement.findPath[i][j].distance, moveCost: + pieceMovement.findPath[i][j].moveCost});
                 }
             }
@@ -201,8 +201,25 @@ let pirates = {
         return resultArray;
     },
 
-
-
+    safeHarbour: function() {
+        for (var i = 0; i < row; i++) {
+            for (var j = 0; j < col; j++) {
+                if (gameBoard.boardArray[i][j].pieces.type == 'fort') {
+                    for (var k = -1; k <= 1; k++) {
+                        for (var l = -1; l <= 1; l++) {
+                            if ((i+k >= 0) && (i+k < row)) {
+                                if ((j+l >= 0) && (j+l < col)) {
+                                    if (gameBoard.boardArray[i+k][j+l].terrain == 'sea') {
+                                        gameBoard.boardArray[i+k][j+l].subTerrain = 'harbour';
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
 
     // LAST BRACKET OF OBJECT
 }


### PR DESCRIPTION
* Safe harbours around forts cannot be entered by pirate ships due to fort cannons, allowing cargo ships to dock and be repaired in safety
* Method added to find safe harbour spaces around forts and add them to boardArray
* Method added to draw safe harbours on map
* Movement.js updated so that pirate ships can no longer enter safe harbours (which also means they do not target cargo ships in harbours)
* Pirate.js logic updated so that pirate ships no longer use telescope on ships in harbours - cargo ships are ignored