### PR TITLE
Repair of team cargo ships in harbours

### DIFF
--- a/board.js
+++ b/board.js
@@ -202,7 +202,8 @@ let gameBoard = {
         this.boardArray[row-4][boardCenter - 1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
         this.boardArray[row-5][boardCenter + 1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
         this.boardArray[row-5][boardCenter].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
-        this.boardArray[row-5][boardCenter -1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0}; */
+        this.boardArray[row-5][boardCenter -1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
+        //*/
 
     },
 
@@ -410,9 +411,21 @@ let gameBoard = {
         cargoSail.setAttribute('fill', 'white');
         cargoSail.style.strokeWidth = '1px';
 
+        // Cargo ship sail SVG design
+        let cargoMast = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        cargoMast.setAttribute('class', localTeam + ' team_stroke');
+        cargoMast.setAttribute('cx', '12.5');
+        cargoMast.setAttribute('cy', '17');
+        cargoMast.setAttribute('r', '1');
+        cargoMast.style.strokeWidth = '1px';
+        cargoMast.style.strokeLinecap = 'round';
+
         // Building the tile
         actionTile.appendChild(cargoDeck);
+        actionTile.appendChild(cargoMast);
         actionTile.appendChild(cargoSail);
+
+        //actionTile.appendChild(shipScaffold);
 
         return actionTile;
     },
@@ -420,6 +433,7 @@ let gameBoard = {
     // Method to damage cargo ship after conflict
     // ------------------------------------------
     damageShip: function(actionTile, localTeam) {
+        actionTile.children[2].remove();
         actionTile.children[1].remove();
 
         let shipOars = document.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -431,6 +445,52 @@ let gameBoard = {
         //shipOars.setAttribute('stroke', 'white');
 
         actionTile.appendChild(shipOars);
+    },
+
+    // Method to repair cargo ship docked in harbour
+    // ---------------------------------------------
+    repairShip: function(actionTile, localTeam, localStatus) {
+        console.log(actionTile.children);
+
+        // Puts up scaffolding
+        if (localStatus == 'repair0') {
+            actionTile.children[1].remove();
+            let shipScaffold = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            shipScaffold.setAttribute('d', 'M 4 4 L 4 23 M 21 4 L 21 23 M 4 8 L 6.5 8 M 21 8 L 18.5 8 M 4 19 L 6 19 M 21 19 L 19 19');
+            shipScaffold.setAttribute('class', localTeam + ' team_stroke');
+            shipScaffold.style.strokeLinejoin = 'round';
+            shipScaffold.style.strokeLinecap = 'round';
+            shipScaffold.style.strokeWidth = '1px';
+            actionTile.appendChild(shipScaffold);
+        }
+
+        // Repairs mast
+        if (localStatus == 'repair1') {
+            let cargoMast = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            cargoMast.setAttribute('class', localTeam + ' team_stroke');
+            cargoMast.setAttribute('cx', '12.5');
+            cargoMast.setAttribute('cy', '17');
+            cargoMast.setAttribute('r', '1');
+            cargoMast.style.strokeWidth = '1px';
+            cargoMast.style.strokeLinecap = 'round';
+            actionTile.appendChild(cargoMast);
+        }
+
+        // Repairs sail
+        if (localStatus == 'repair2') {
+            // Cargo ship sail SVG design
+            let cargoSail = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            cargoSail.setAttribute('d', 'M 2 16 L 22 16 C 20.5 13.5 16.5 12 12 12 C 7.5 12 3.5 13.5 2 16 Z');
+            cargoSail.setAttribute('class', localTeam + ' team_stroke');
+            cargoSail.setAttribute('fill', 'white');
+            cargoSail.style.strokeWidth = '1px';
+            actionTile.appendChild(cargoSail);
+        }
+
+        // Removes scaffolding
+        if (localStatus == 'good') {
+            actionTile.children[1].remove();
+        }
     },
 
     // Method to create fort tile

--- a/main.js
+++ b/main.js
@@ -202,6 +202,9 @@ endTurn.addEventListener('click', function() {
     // Manage goods
     stockDashboard.newTurnGoods();
 
+    // Repair ships
+    pieceMovement.harbourRepair();
+
     // Update the stock dashboard
     stockDashboard.stockTake();
     stockDashboard.drawStock();
@@ -377,7 +380,6 @@ boardMarkNode.addEventListener('click', function(event) {
 
     // "Start" piece validation on first click
     if (startEnd == 'start') {
-        console.log(pieceMovement.movementArray.start);
         // Commentary on tile clicked on
         clearCommentary();
         commentary.appendChild(gameBoard.createActionTile(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, pieceMovement.movementArray.start.pieces.type, pieceMovement.movementArray.start.pieces.team, 'startPiece', 10, (screenWidth - 2*surroundSize) * 0.3 - (gridSize + 2*tileBorder)/2, 1.5, 0));
@@ -402,7 +404,7 @@ boardMarkNode.addEventListener('click', function(event) {
 
             // Claiming of unclaimed resources
             if (pieceMovement.movementArray[startEnd].pieces.category == 'Resources' && pieceMovement.movementArray[startEnd].pieces.type != 'desert' && pieceMovement.movementArray[startEnd].pieces.team == 'Unclaimed') {
-                // Check that this resource type i snot already held by player
+                // Check that this resource type is not already held by player
                 let pieceTotalsTeamPosition = stockDashboard.pieceTotals.findIndex(fI => fI.team == gameManagement.turn);
                 if(stockDashboard.pieceTotals[pieceTotalsTeamPosition].pieces[pieceMovement.movementArray.start.pieces.type] == 0) {
                     if (pieceMovement.shipAvailable('crew') == 'crew') {
@@ -430,11 +432,15 @@ boardMarkNode.addEventListener('click', function(event) {
 
             // Piece movement
             } else if (pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn && pieceMovement.movementArray[startEnd].pieces.used == 'unused') {
-                if (pieceMovement.movementArray[startEnd].pieces.type == 'cargo ship') {
+                if (pieceMovement.movementArray[startEnd].pieces.type == 'cargo ship' && (pieceMovement.movementArray[startEnd].pieces.damageStatus == 'good' || pieceMovement.movementArray[startEnd].pieces.damageStatus == 'damaged')) {
                     secondLineComment.innerText = 'Click any red tile to move';
                     // If "Start" piece is validated startEnd gate is opened and potential tiles are activated
                     startEnd = 'end';
-                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, true);
+                    if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
+                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, true, 'damaged');
+                    } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
+                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, true, 'good');
+                    }
                     // Redraw gameboard to show activated tiles
                     gameBoard.drawActiveTiles();
                 }
@@ -473,7 +479,6 @@ boardMarkNode.addEventListener('click', function(event) {
     // Once "start" piece has been selected second click needs to be to an active "end" square
     // Piece move is then made
     } else if (startEnd == 'end') {
-        console.log(pieceMovement.movementArray.end);
         // Removing commentary
         commentary.style.bottom = '-10%';
         if (pieceMovement.movementArray.end.activeStatus == 'active') {
@@ -509,15 +514,12 @@ boardMarkNode.addEventListener('click', function(event) {
             } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == 'Kingdom' && pieceMovement.movementArray.end.pieces.type == 'fort') {
                 pieceMovement.deactivateTiles(1);
                 gameBoard.drawActiveTiles();
-
-                console.log(pieceMovement.movementArray.start);
-                console.log('passed', pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
                 tradeContracts.discoverPath(pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
                 tradeContracts.fulfilDelivery();
                 tradeContracts.drawContracts();
 
             // Unloading to own team fort or resource tile
-          } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == gameManagement.turn && (pieceMovement.movementArray.end.pieces.type == 'fort' || pieceMovement.movementArray.end.pieces.category == 'Resources')) {
+            } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == gameManagement.turn && (pieceMovement.movementArray.end.pieces.type == 'fort' || pieceMovement.movementArray.end.pieces.category == 'Resources')) {
                 pieceMovement.deactivateTiles(maxMove);
                 gameBoard.drawActiveTiles();
                 //loadingStock = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock;

--- a/pirates.js
+++ b/pirates.js
@@ -13,13 +13,21 @@ let pirates = {
         // Loop through each pirate ship with delay to allow transormations to occur
         let i = 0;
         function moves() {
+                // Resets movement array
+                pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
+
                 pathDistance = 0;
                 //console.log(' -------------------- pirate ship: ' + i);
                 // Starting tile for pirate ship move taken from array of pirate ships
                 pieceMovement.movementArray.start = pirates.pirateShips[i].start;
                 // Tiles activated which also finds path for moves and target information on reachable area
                 // true / false allow red boundaries to be highlighted or not
-                pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, false);
+                if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
+                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, false, 'damaged');
+                } else {
+                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, false, 'good');
+                }
+
                 //console.log('findPath', pieceMovement.findPath);
                 // Redraw active tile layer after activation to show activated tiles
                 gameBoard.drawActiveTiles();
@@ -72,8 +80,6 @@ let pirates = {
                 stockDashboard.stockTake();
                 stockDashboard.drawStock();
 
-                // Resets movement array
-                pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
                 // Moves on to next ship
                 i+=1;
 


### PR DESCRIPTION
Cargo ships damaged in battles with pirates must return to a safe harbour for repairs. There they must miss two turns as the ship is repaired.
* Reduction of cargo ship movements to 2 tiles in all directions (rowing as no sail)
* Addition of graphics method for step-wise repair of cargo ships in harbours (scaffolding, mast, sail)
* Method to handle damaged ship arrival in safe harbour
* Method to check for cargo ships to repair at start of turn