### PR TITLE
Pirate harbours and repair

### DIFF
--- a/board.js
+++ b/board.js
@@ -156,27 +156,31 @@ let gameBoard = {
 
 
         // Creation of ships
-        this.boardArray[boardCenter-1][col-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-90', used: 'unused', damageStatus: 'good', team: 'Orange Team', goods: 'none', stock: 0};
-        this.boardArray[boardCenter+1][col-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-90', used: 'unused', damageStatus: 'good', team: 'Orange Team', goods: 'none', stock: 0};
-        this.boardArray[0][boardCenter-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '180', used: 'unused', damageStatus: 'good', team: 'Red Team', goods: 'none', stock: 0};
-        this.boardArray[0][boardCenter+1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '180', used: 'unused', damageStatus: 'good', team: 'Red Team', goods: 'none', stock: 0};
-        this.boardArray[row-1][boardCenter-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '0', used: 'unused', damageStatus: 'good', team: 'Green Team', goods: 'none', stock: 0};
-        this.boardArray[row-1][boardCenter+1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '0', used: 'unused', damageStatus: 'good', team: 'Green Team', goods: 'none', stock: 0};
-        this.boardArray[boardCenter-1][0].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '90', used: 'unused', damageStatus: 'good', team: 'Blue Team', goods: 'none', stock: 0};
-        this.boardArray[boardCenter+1][0].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '90', used: 'unused', damageStatus: 'good', team: 'Blue Team', goods: 'none', stock: 0};
+        this.boardArray[boardCenter-1][col-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-90', used: 'unused', damageStatus: 'good', team: 'Orange Team', goods: 'none', stock: 0, homeRow: boardCenter-1, homeCol: col-1};
+        this.boardArray[boardCenter+1][col-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-90', used: 'unused', damageStatus: 'good', team: 'Orange Team', goods: 'none', stock: 0, homeRow: boardCenter+1, homeCol: col-1};
+        this.boardArray[0][boardCenter-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '180', used: 'unused', damageStatus: 'good', team: 'Red Team', goods: 'none', stock: 0, homeRow: 0, homeCol: boardCenter-1};
+        this.boardArray[0][boardCenter+1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '180', used: 'unused', damageStatus: 'good', team: 'Red Team', goods: 'none', stock: 0, homeRow: 0, homeCol: boardCenter+1};
+        this.boardArray[row-1][boardCenter-1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '0', used: 'unused', damageStatus: 'good', team: 'Green Team', goods: 'none', stock: 0, homeRow: row-1, homeCol: boardCenter-1};
+        this.boardArray[row-1][boardCenter+1].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '0', used: 'unused', damageStatus: 'good', team: 'Green Team', goods: 'none', stock: 0, homeRow: row-1, homeCol: boardCenter+1};
+        this.boardArray[boardCenter-1][0].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '90', used: 'unused', damageStatus: 'good', team: 'Blue Team', goods: 'none', stock: 0, homeRow: boardCenter-1, homeCol: 0};
+        this.boardArray[boardCenter+1][0].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '90', used: 'unused', damageStatus: 'good', team: 'Blue Team', goods: 'none', stock: 0, homeRow: boardCenter+1, homeCol: 0};
 
-        // Creation of pirate ships
-        this.boardArray[4][6].terrain = 'sea';
-        this.boardArray[4][6].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
+        // Creation of pirate ships and pirate harbours
+        this.boardArray[4][6] = {xpos: 4, ypos: 6, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: 4, homeCol: 6}};
+        //this.boardArray[4][6].terrain = 'sea';
+        //this.boardArray[4][6].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[row-7][4].terrain = 'sea';
-        this.boardArray[row-7][4].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
+        this.boardArray[row-7][4] = {xpos: row-7, ypos: 4, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: row-7, homeCol: 4}};
+        //this.boardArray[row-7][4].terrain = 'sea';
+        //this.boardArray[row-7][4].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[row-5][col-7].terrain = 'sea';
-        this.boardArray[row-5][col-7].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
+        this.boardArray[row-5][col-7] = {xpos: row-5, ypos: col-7, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: row-5, homeCol: col-7}};
+        //this.boardArray[row-5][col-7].terrain = 'sea';
+        //this.boardArray[row-5][col-7].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[6][col-5].terrain = 'sea';
-        this.boardArray[6][col-5].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
+        this.boardArray[6][col-5] = {xpos: 6, ypos: col-5, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: 6, homeCol: col-5}};
+        //this.boardArray[6][col-5].terrain = 'sea';
+        //this.boardArray[6][col-5].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
         // Creation of forests
         this.boardArray[boardCenter-1][boardCenter].pieces = {populatedSquare: true, category: 'Resources', type: 'forest', direction: '0', used: 'unused', damageStatus: 'good', team: 'Kingdom', goods: 'wood', stock: 0};
@@ -433,6 +437,7 @@ let gameBoard = {
     // Method to damage cargo ship after conflict
     // ------------------------------------------
     damageShip: function(actionTile, localTeam) {
+        console.log(actionTile.children);
         actionTile.children[2].remove();
         actionTile.children[1].remove();
 
@@ -989,7 +994,7 @@ let gameBoard = {
         for (var h = 0; h < octagonArray.length; h++) {
             this.drawTiles (octagonArray[h].type, canvasBoard, octagonArray[h].gap, octagonArray[h].width, octagonArray[h].colour, octagonArray[h].background)
         }
-        this.drawSafeHarbours();
+        this.drawHarbours();
         this.drawCompass();
 
     },
@@ -1033,6 +1038,10 @@ let gameBoard = {
                 } else if (octagonType=='harbour' && this.boardArray[i][j].subTerrain == 'harbour') {
                     // Draws safe harbours - on a separate canvas overlay
                     this.drawOctagon(boardLayer, ocatagonGap);
+                } else if (octagonType=='pirateHarbour' && this.boardArray[i][j].subTerrain == 'pirateHarbour') {
+                    // Draws safe harbours - on a separate canvas overlay
+                    this.drawOctagon(boardLayer, ocatagonGap);
+
                 } else if (octagonType=='land' && this.boardArray[i][j].terrain == 'land') {
                     // Islands
                     this.drawOctagon(boardLayer, ocatagonGap);
@@ -1059,15 +1068,20 @@ let gameBoard = {
         gameBoard.drawTiles ('active', canvasActive, 0, 1, 'rgb(255, 153, 153)', 'transparent');
 
         // safe harbours are also drawn on canvasActive later - can be changed later if necessary
-        this.drawSafeHarbours();
+        this.drawHarbours();
     },
 
     // Method to add safe harbours to the map
     // --------------------------------------
-    drawSafeHarbours: function () {
+    drawHarbours: function () {
         // safe harbours are also drawn on canvasActive later - can be changed later if necessary
-        gameBoard.drawTiles ('harbour', canvasActive, 0, 1, 'transparent', 'rgb(233, 211, 183)');
+        this.drawTiles ('harbour', canvasActive, 0, 1, 'transparent', 'rgb(233, 211, 183)');
+        this.drawTiles ('pirateHarbour', canvasActive, 0, 1, '#353839', 'rgb(233, 211, 183)');
+        //this.drawTiles ('pirateHarbour', canvasActive, 0, 1, 'darkgrey', 'darkgrey');
+        //this.drawTiles ('pirateHarbour', canvasActive, 0, 1, 'rgb(138, 87, 50)', 'rgb(138, 87, 50)');
+
     },
+
 
     // Method to draw octagons for creation of board
     // ---------------------------------------------

--- a/main.js
+++ b/main.js
@@ -156,6 +156,7 @@ tradeContracts.drawContracts();
 
 stockDashboard.goodsStockTake();
 
+  console.log(gameBoard.boardArray);
 
 
 // Set up of compass
@@ -215,6 +216,7 @@ endTurn.addEventListener('click', function() {
     // Update the goods dashboard
     stockDashboard.goodsStockTake();
 
+    console.log(gameBoard.boardArray);
 
 });
 
@@ -437,9 +439,9 @@ boardMarkNode.addEventListener('click', function(event) {
                     // If "Start" piece is validated startEnd gate is opened and potential tiles are activated
                     startEnd = 'end';
                     if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
-                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, true, 'damaged');
+                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, 2, true, 'damaged');
                     } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
-                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, true, 'good');
+                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, maxMove, true, 'good');
                     }
                     // Redraw gameboard to show activated tiles
                     gameBoard.drawActiveTiles();

--- a/pirates.js
+++ b/pirates.js
@@ -15,64 +15,80 @@ let pirates = {
         function moves() {
                 // Resets movement array
                 pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
+                pirates.conflictArray = {conflict: false, start: {row: '', col: ''}, end: {row: '', col: ''}};
 
-                pathDistance = 0;
-                //console.log(' -------------------- pirate ship: ' + i);
+                let pathDistance = 0;
+                console.log(' -------------------- pirate ship: ' + i);
                 // Starting tile for pirate ship move taken from array of pirate ships
                 pieceMovement.movementArray.start = pirates.pirateShips[i].start;
                 // Tiles activated which also finds path for moves and target information on reachable area
                 // true / false allow red boundaries to be highlighted or not
                 if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
-                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, false, 'damaged');
-                } else {
-                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, false, 'good');
+                    console.log('damaged start');
+                    let searchRange = Math.max(Math.abs(pirates.pirateShips[i].start.pieces.homeRow - pirates.pirateShips[i].start.row), Math.abs(pirates.pirateShips[i].start.pieces.homeCol - pirates.pirateShips[i].start.col));
+                    console.log(searchRange);
+                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, searchRange, true, 'damaged');
+                } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
+                    console.log('good start');
+                    pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, maxMove, true, 'good');
                 }
-
                 //console.log('findPath', pieceMovement.findPath);
                 // Redraw active tile layer after activation to show activated tiles
                 gameBoard.drawActiveTiles();
-                pirates.conflictArray = {conflict: false, start: {row: '', col: ''}, end: {row: '', col: ''}};
-                // Finds targetable cargo ships within reach, then cuts down array based on distance and move cost
-                pirates.findTarget();
-                pirates.useTelescope();
-                if ((pirates.targetCargo.length > 0) && (pirates.pirateShips[i].start.pieces.damageStatus != 'damaged')) {
-                    //console.log('targetCargo - before', pirates.targetCargo);
-                    pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'distance');
-                    pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'moveCost');
-                    //console.log('targetCargo - min', pirates.targetCargo);
-                    pathDistance = pirates.targetCargo[0].distance;
-                    // Attacks targetable cargo ship if in range (currently just uses first cargo ship in array - to improve in future)
-                    // Keep - useful for debugging - console.log('found target: ' + pirates.targetCargo[0].row + ' ' + pirates.targetCargo[0].col);
-                    lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path, -1);
-                    pirates.pirateShips[i].end.row = pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path[lastTile].fromRow;
-                    pirates.pirateShips[i].end.col = pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path[lastTile].fromCol;
-                    //console.log('launch ship conflict', pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, pirates.targetCargo[0].row, pirates.targetCargo[0].col);
-                    //pieceMovement.shipConflict(pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, pirates.targetCargo[0].row, pirates.targetCargo[0].col);
-                    pirates.conflictArray = {conflict: true, pirate: {row: pirates.pirateShips[i].end.row, col: pirates.pirateShips[i].end.col}, ship: {row: pirates.targetCargo[0].row, col: pirates.targetCargo[0].col}};
-                } else if (pirates.targetTelescope.length > 0 && (pirates.pirateShips[i].start.pieces.damageStatus != 'damaged')) {
-                    // Finds cargo ships within visual range (localMaxMove) then cuts down array based on minimum distance and move cost
-                    //console.log('targetTelescope - before', pirates.targetTelescope);
-                    pirates.targetTelescope = pirates.minArray(pirates.targetTelescope, 'distance');
-                    pirates.targetTelescope = pirates.minArray(pirates.targetTelescope, 'moveCost');
-                    //console.log('targetTelescope - min', pirates.targetTelescope);
-                    pathDistance = pirates.targetTelescope[0].distance;
-                    lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path, 0);
-                    pirates.pirateShips[i].end.row = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromRow;
-                    pirates.pirateShips[i].end.col = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromCol;
-                    //console.log('findLast', pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, 0);
-                } else {
-                    // If no ships in active range or visual range moves to maximum distance at minimum wind cost
-                    pirates.maxPathDistance();
-                    pirates.minCostTiles = pirates.minArray(pirates.maxDistanceTiles, 'moveCost');
-                    pathDistance = pirates.minCostTiles[0].distance;
-                    //console.log('minCostTiles', pirates.minCostTiles);
-                    // Keep - useful for debugging - console.log('just moving: ' + pirates.minCostTiles[0].row + ' ' + pirates.minCostTiles[0].col);
-                    pirates.pirateShips[i].end.row = pirates.minCostTiles[0].row;
-                    pirates.pirateShips[i].end.col = pirates.minCostTiles[0].col;
+
+                if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
+                    console.log('damaged end');
+                    lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.pirateShips[i].start.pieces.homeRow][pirates.pirateShips[i].start.pieces.homeCol].path, 0);
+                    pirates.pirateShips[i].end.row = pieceMovement.findPath[pirates.pirateShips[i].start.pieces.homeRow][pirates.pirateShips[i].start.pieces.homeCol].path[lastTile].fromRow;
+                    pirates.pirateShips[i].end.col = pieceMovement.findPath[pirates.pirateShips[i].start.pieces.homeRow][pirates.pirateShips[i].start.pieces.homeCol].path[lastTile].fromCol;
+                    pathDistance = 2;
+
+                } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
+                    console.log('good end');
+
+                    // Finds targetable cargo ships within reach, then cuts down array based on distance and move cost
+                    pirates.findTarget();
+                    pirates.useTelescope();
+                    if ((pirates.targetCargo.length > 0) && (pirates.pirateShips[i].start.pieces.damageStatus != 'damaged')) {
+                        //console.log('targetCargo - before', pirates.targetCargo);
+                        pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'distance');
+                        pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'moveCost');
+                        //console.log('targetCargo - min', pirates.targetCargo);
+                        pathDistance = pirates.targetCargo[0].distance;
+                        // Attacks targetable cargo ship if in range (currently just uses first cargo ship in array - to improve in future)
+                        // Keep - useful for debugging - console.log('found target: ' + pirates.targetCargo[0].row + ' ' + pirates.targetCargo[0].col);
+                        lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path, -1);
+                        pirates.pirateShips[i].end.row = pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path[lastTile].fromRow;
+                        pirates.pirateShips[i].end.col = pieceMovement.findPath[pirates.targetCargo[0].row][pirates.targetCargo[0].col].path[lastTile].fromCol;
+                        //console.log('launch ship conflict', pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, pirates.targetCargo[0].row, pirates.targetCargo[0].col);
+                        //pieceMovement.shipConflict(pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, pirates.targetCargo[0].row, pirates.targetCargo[0].col);
+                        pirates.conflictArray = {conflict: true, pirate: {row: pirates.pirateShips[i].end.row, col: pirates.pirateShips[i].end.col}, ship: {row: pirates.targetCargo[0].row, col: pirates.targetCargo[0].col}};
+                    } else if (pirates.targetTelescope.length > 0 && (pirates.pirateShips[i].start.pieces.damageStatus != 'damaged')) {
+                        // Finds cargo ships within visual range (localMaxMove) then cuts down array based on minimum distance and move cost
+                        //console.log('targetTelescope - before', pirates.targetTelescope);
+                        pirates.targetTelescope = pirates.minArray(pirates.targetTelescope, 'distance');
+                        pirates.targetTelescope = pirates.minArray(pirates.targetTelescope, 'moveCost');
+                        //console.log('targetTelescope - min', pirates.targetTelescope);
+                        pathDistance = pirates.targetTelescope[0].distance;
+                        lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path, 0);
+                        pirates.pirateShips[i].end.row = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromRow;
+                        pirates.pirateShips[i].end.col = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromCol;
+                        //console.log('findLast', pirates.pirateShips[i].end.row, pirates.pirateShips[i].end.col, 0);
+                    } else {
+                        // If no ships in active range or visual range moves to maximum distance at minimum wind cost
+                        pirates.maxPathDistance();
+                        pirates.minCostTiles = pirates.minArray(pirates.maxDistanceTiles, 'moveCost');
+                        pathDistance = pirates.minCostTiles[0].distance;
+                        //console.log('minCostTiles', pirates.minCostTiles);
+                        // Keep - useful for debugging - console.log('just moving: ' + pirates.minCostTiles[0].row + ' ' + pirates.minCostTiles[0].col);
+                        pirates.pirateShips[i].end.row = pirates.minCostTiles[0].row;
+                        pirates.pirateShips[i].end.col = pirates.minCostTiles[0].col;
+                    }
                 }
+                console.log('general');
                 // End position for pirate ship confirmed with movement array then move activated and dashboard recalculated
                 pieceMovement.movementArray.end = pirates.pirateShips[i].end;
-                //console.log('pirates movement array', pieceMovement.movementArray);
+                console.log('pirates movement array', pieceMovement.movementArray);
                 pieceMovement.deactivateTiles(maxMove);
                 pieceMovement.shipTransition(gameSpeed);
 


### PR DESCRIPTION
After adding harbour repair to cargo ships the next stage was to create pirate harbours and add pirateHarbour repairs
* Added homeRow and homeCol to all Transport pieces so pirate ships know where to get repaired. 
* Updated activateTiles in movement.js so that separate search range and maximum look range can be passed. This allows pirate ships to find a route to their home tile. 
* Added pirate logic to harbourRepairArrival, harbourRepair, drawHarbours.
* Update pirate.js logic to handle new logic priority for damaged ships. 