### PR TITLE
Removal of event listeners during transitions

### DIFF
--- a/gamemanagement.js
+++ b/gamemanagement.js
@@ -53,6 +53,7 @@ let gameManagement = {
         } else if (e.target.classList.contains('icon6')) {
             this.clearPanel();
             settingsPopup.style.display = "none";
+            window.removeEventListener('click', popRunClose);
         }
     },
 

--- a/main.js
+++ b/main.js
@@ -197,17 +197,29 @@ needle.style.transform = 'rotate(' + needleDirection + 'deg)';
 
 // Next turn functionality
 // -----------------------
-var endTurn = document.querySelector('.endturnmark');
-endTurn.setAttribute('class', gameManagement.turn + ' team_fill team_stroke');
-gameManagement.createTurnCircle(false, 0.7*surroundSize/100, -20*screenReduction, 0.15*surroundSize, endTurn, 'icon_holder');
 
-endTurn.addEventListener('click', function() {
+function nextTurn() {
     // Used pieces are resert to unused
+    if(workFlow == 1) {console.log(' ------ Next turn: ---------: ' + (Date.now() - launchTime)); }
+    // Resetting if second click not applied
+    pieceMovement.deactivateTiles(maxMove);
+    gameBoard.drawActiveTiles();
+
+    // Resetting movement array in case second click has not been made
+    pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
+    startEnd = 'start';
+
+    // Removing commentary goods event handler
+    commentary.removeEventListener('click', clickGoods);
+    clearCommentary();
+
+    // Resetting used pieces
     pieceMovement.usedPiecesReset();
+
     // Team is changed
     gameManagement.nextTurn();
 
-    if(workFlow == 1) {console.log(' ------ Next turn: ' + gameManagement.turn + ' ---------: ' + (Date.now() - launchTime)); }
+    if(workFlow == 1) {console.log('Turn changed to ' + gameManagement.turn + ' : ' + (Date.now() - launchTime)); }
     if(gameBoardTrack == 1) {console.log(gameBoard.boardArray); }
 
     // Wind direction is set for next turn
@@ -248,8 +260,13 @@ endTurn.addEventListener('click', function() {
         // Update the goods dashboard
         stockDashboard.goodsStockTake();
     }
+}
 
-});
+var endTurn = document.querySelector('.endturnmark');
+endTurn.setAttribute('class', gameManagement.turn + ' team_fill team_stroke');
+gameManagement.createTurnCircle(false, 0.7*surroundSize/100, -20*screenReduction, 0.15*surroundSize, endTurn, 'icon_holder');
+endTurn.addEventListener('click', nextTurn);
+
 
 // Settings pop-up box
 // --------------------
@@ -275,16 +292,19 @@ settingsIcon.addEventListener('click', function() {
     settingsPopup.style.display = "block";
     popupCog.style.display = "block";
     // Event handler for settings pop up once launched
-    window.addEventListener('click', function(e) {
-        console.log('window event listener');
-        if (e.target == settingsPopup) {
-            gameManagement.clearPanel();
-            settingsPopup.style.display = "none";
-        } else {
-            gameManagement.manageSettings(e, screenWidth*(12/2000));
-        }
-    });
+    window.addEventListener('click', popRunClose);
 });
+
+function popRunClose(e) {
+    console.log('window event listener');
+    if (e.target == settingsPopup) {
+        gameManagement.clearPanel();
+        settingsPopup.style.display = "none";
+        window.removeEventListener('click', popRunClose);
+    } else {
+        gameManagement.manageSettings(e, screenWidth*(12/2000));
+    }
+};
 
 // ------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------
@@ -404,14 +424,9 @@ function clickGoods(e) {
 // Event handler for board
 // -----------------------
 
-// boardMarkNode is board holder in document
-let boardMarkLeft = boardMarkNode.offsetLeft;
-let boardMarkTop = boardMarkNode.offsetTop;
 
-//console.log('here', boardMarkLeft, boardMarkTop);
-
-boardMarkNode.addEventListener('click', function(event) {
-    if(workFlow == 1) {console.log('Board mark node click event listener triggered: ' + (Date.now() - launchTime)); }
+function boardHandler(event) {
+    if(workFlow == 1) {console.log('Board mark node click event listener triggered. Start/End = ' + startEnd + ': ' + (Date.now() - launchTime)); }
     let xClick = event.pageX - boardMarkLeft;
     let yClick = event.pageY - boardMarkTop;
 
@@ -486,6 +501,8 @@ boardMarkNode.addEventListener('click', function(event) {
                     }
                     // Redraw gameboard to show activated tiles
                     gameBoard.drawActiveTiles();
+                    console.log('within boardMArkNode loop');
+                    console.log(pieceMovement.movementArray);
                 }
             }
 
@@ -577,6 +594,8 @@ boardMarkNode.addEventListener('click', function(event) {
 
             // Piece movement
             } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship') {
+                endTurn.removeEventListener('click', nextTurn);
+                boardMarkNode.removeEventListener('click', boardHandler);
                 pieceMovement.deactivateTiles(maxMove);
                 // Redraw active tile layer after deactivation to remove activated tiles
                 gameBoard.drawActiveTiles();
@@ -601,4 +620,12 @@ boardMarkNode.addEventListener('click', function(event) {
         stockDashboard.stockTake();
         stockDashboard.drawStock();
     }
-});
+};
+
+// boardMarkNode is board holder in document
+let boardMarkLeft = boardMarkNode.offsetLeft;
+let boardMarkTop = boardMarkNode.offsetTop;
+
+//console.log('here', boardMarkLeft, boardMarkTop);
+
+boardMarkNode.addEventListener('click', boardHandler);

--- a/movement.js
+++ b/movement.js
@@ -214,7 +214,7 @@ let pieceMovement = {
     // Method to deactivate tiles after a piece has moved
     // --------------------------------------------------
     deactivateTiles: function(localMaxMove) {
-        if(workFlow == 1) {console.log('Active tiles deactivated'); }
+        if(workFlow == 1) {console.log('Active tiles deactivated: ' + (Date.now() - launchTime)); }
         let moveDistance = localMaxMove;
         // Simply deactivates all tiles within the maximum potential move distance
         for (var i = -moveDistance; i < moveDistance + 1; i++) {
@@ -233,7 +233,7 @@ let pieceMovement = {
     // Method to reset pieces from 'used' to 'unused' once a turn has ended
     // --------------------------------------------------------------------
     usedPiecesReset: function() {
-        if(workFlow == 1) {console.log('Used pieces reset'); }
+        if(workFlow == 1) {console.log('Used pieces reset: ' + (Date.now() - launchTime)); }
         for (var y = 0; y <  col; y++) {
             for (var x = 0; x <  row; x++) {
                 if (gameBoard.boardArray[x][y].pieces.used == 'used') {
@@ -411,6 +411,8 @@ let pieceMovement = {
             // Resetting movement array once second click has been made (if move valid)
             pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
             startEnd = 'start';
+            endTurn.addEventListener('click', nextTurn);
+            boardMarkNode.addEventListener('click', boardHandler);
         } else if (gameManagement.turn == 'Pirate') {
 
             // Resetting movement array once second click has been made (if move valid)

--- a/pirates.js
+++ b/pirates.js
@@ -88,13 +88,15 @@ let pirates = {
             }
             pieceMovement.deactivateTiles(maxMove);
             pieceMovement.shipTransition(gameSpeed);
-            
+
           }
       },
 
     // Method to manage automated movement of pirate ship moves
     automatePirates: function() {
         if(workFlow == 1) {console.log('Automate pirates - ship to move or completion: ' + (Date.now() - launchTime)); }
+        endTurn.removeEventListener('click', nextTurn);
+        boardMarkNode.removeEventListener('click', boardHandler);
         if (pirates.pirateCount == -1) {
             // Generate array of all pirate ships to be moved
             this.populatePirateShipsArray();
@@ -116,6 +118,8 @@ let pirates = {
             // Resets pirate ship array once all moves made
             pirates.pirateShips = [];
             pirates.pirateCount = -1;
+            endTurn.addEventListener('click', nextTurn);
+            boardMarkNode.addEventListener('click', boardHandler);
         }
 
     },


### PR DESCRIPTION
Event listeners removed during transitions to prevent leaking of move data from one event to the next.

* end turn button listener removed during transitions
* board event listener removed during transitions
* settings box listener also removed once settings pop up closed
* next turn functionality also updated for more complete reset (for example active tiles are now removed and redrawn so that they disappear when next turn is applied)