### PR TITLE
Removal of off-board click error

### DIFF
--- a/main.js
+++ b/main.js
@@ -432,195 +432,198 @@ function boardHandler(event) {
 
     let xClickTile = Math.floor((xClick - boardSurround) / (gridSize + tileBorder * 2));
     let yClickTile = Math.floor((yClick - boardSurround) / (gridSize + tileBorder * 2));
+    console.log(yClickTile, xClickTile);
+    if((xClickTile >= 0 && xClickTile < col) && (yClickTile >= 0 && yClickTile < row)) {
 
-    // Obtain details of most recent tile clicked on - separated between start and end points
-    pieceMovement.captureMove(startEnd, yClickTile, xClickTile);
+        // Obtain details of most recent tile clicked on - separated between start and end points
+        pieceMovement.captureMove(startEnd, yClickTile, xClickTile);
 
-    // "Start" piece validation on first click
-    if (startEnd == 'start') {
-        // Commentary on tile clicked on
-        clearCommentary();
-        commentary.appendChild(gameBoard.createActionTile(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, pieceMovement.movementArray.start.pieces.type, pieceMovement.movementArray.start.pieces.team, 'startPiece', 10, (screenWidth - 2*surroundSize) * 0.3 - (gridSize + 2*tileBorder)/2, 1.5, 0));
-        for (var i = 0; i < pieceMovement.movementArray.start.pieces.stock; i++) {
-            //console.log(gameBoard.createIcon('stock' + i, 1.5, pieceMovement.movementArray.start.pieces.goods, (screenWidth - 2*surroundSize) * 0.6 + ((i+2) * (gridSize + tileBorder) / 1.5), 10));
-            commentary.appendChild(gameBoard.createIcon('stock' + i, 1.5, pieceMovement.movementArray.start.pieces.goods, (screenWidth - 2*surroundSize) * 0.7 - tileBorder/2 + (((i % 10) - 0.5) * (gridSize + tileBorder) / 1.5), 10 + Math.floor(i/10) * ((gridSize + tileBorder) / 1.5)));
-        }
-
-        firstLineComment.innerText = pieceMovement.movementArray[startEnd].pieces.team + ' ' + pieceMovement.movementArray[startEnd].pieces.type;
-        if (pieceMovement.movementArray[startEnd].pieces.stock > 0) {
-              firstLineComment.insertAdjacentText('beforeend', ' - ' + pieceMovement.movementArray[startEnd].pieces.goods + ": " + pieceMovement.movementArray[startEnd].pieces.stock);
-        }
-        commentary.style.bottom = 0;
-
-        // commentary event handler for goods
-        if(pieceMovement.movementArray.start.pieces.team == gameManagement.turn && pieceMovement.movementArray.start.pieces.stock > 0) {
-            secondLineComment.innerText = 'Select quantity of goods to load';
-            commentary.addEventListener('click', clickGoods);
-        }
-
-        if (pieceMovement.movementArray[startEnd].pieces.populatedSquare) {
-
-            // Claiming of unclaimed resources
-            if (pieceMovement.movementArray[startEnd].pieces.category == 'Resources' && pieceMovement.movementArray[startEnd].pieces.type != 'desert' && pieceMovement.movementArray[startEnd].pieces.team == 'Unclaimed') {
-                // Check that this resource type is not already held by player
-                let pieceTotalsTeamPosition = stockDashboard.pieceTotals.findIndex(fI => fI.team == gameManagement.turn);
-                if(stockDashboard.pieceTotals[pieceTotalsTeamPosition].pieces[pieceMovement.movementArray.start.pieces.type] == 0) {
-                    if (pieceMovement.shipAvailable('crew') == 'crew') {
-                        // TO ADD - Check that ship has not previously landed crew somewhere
-                        secondLineComment.innerText = 'Click ship to land team and claim resource';
-                        startEnd = 'end';
-                        gameBoard.drawActiveTiles();
-                    }
-                } else {
-                    secondLineComment.innerText = 'You have already claimed your ' + pieceMovement.movementArray[startEnd].pieces.type;
-                }
-
-            // Loading of a ship
-          } else if (((pieceMovement.movementArray.start.pieces.category == 'Resources' && pieceMovement.movementArray.start.pieces.type != 'desert') || pieceMovement.movementArray.start.pieces.category == 'Settlements') && pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn) {
-                if (pieceMovement.shipAvailable(pieceMovement.movementArray.start.pieces.goods) == 'compatible') {
-                    if (pieceMovement.movementArray.start.pieces.stock > 0) {
-                        startEnd = 'end';
-                        gameBoard.drawActiveTiles();
-                    } else if (pieceMovement.movementArray.start.pieces.stock == 0) {
-                        secondLineComment.innerText = 'No goods to be loaded';
-                    }
-                } else if (pieceMovement.shipAvailable(pieceMovement.movementArray.start.pieces.goods) == 'incompatible') {
-                    secondLineComment.innerText = 'Docked ship already carrying different goods';
-                }
-
-            // Piece movement
-            } else if (pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn && pieceMovement.movementArray[startEnd].pieces.used == 'unused') {
-                if (pieceMovement.movementArray[startEnd].pieces.type == 'cargo ship' && (pieceMovement.movementArray[startEnd].pieces.damageStatus == 'good' || pieceMovement.movementArray[startEnd].pieces.damageStatus == 'damaged')) {
-                    secondLineComment.innerText = 'Click any red tile to move';
-                    // If "Start" piece is validated startEnd gate is opened and potential tiles are activated
-                    startEnd = 'end';
-                    if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
-                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, 2, true, 'damaged');
-                    } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
-                        pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, maxMove, true, 'good');
-                    }
-                    // Redraw gameboard to show activated tiles
-                    gameBoard.drawActiveTiles();
-                    console.log('within boardMArkNode loop');
-                    console.log(pieceMovement.movementArray);
-                }
+        // "Start" piece validation on first click
+        if (startEnd == 'start') {
+            // Commentary on tile clicked on
+            clearCommentary();
+            commentary.appendChild(gameBoard.createActionTile(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, pieceMovement.movementArray.start.pieces.type, pieceMovement.movementArray.start.pieces.team, 'startPiece', 10, (screenWidth - 2*surroundSize) * 0.3 - (gridSize + 2*tileBorder)/2, 1.5, 0));
+            for (var i = 0; i < pieceMovement.movementArray.start.pieces.stock; i++) {
+                //console.log(gameBoard.createIcon('stock' + i, 1.5, pieceMovement.movementArray.start.pieces.goods, (screenWidth - 2*surroundSize) * 0.6 + ((i+2) * (gridSize + tileBorder) / 1.5), 10));
+                commentary.appendChild(gameBoard.createIcon('stock' + i, 1.5, pieceMovement.movementArray.start.pieces.goods, (screenWidth - 2*surroundSize) * 0.7 - tileBorder/2 + (((i % 10) - 0.5) * (gridSize + tileBorder) / 1.5), 10 + Math.floor(i/10) * ((gridSize + tileBorder) / 1.5)));
             }
 
-            // Unloading of a ship
-            if (pieceMovement.movementArray.start.pieces.team == gameManagement.turn && pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.start.pieces.stock > 0) {
+            firstLineComment.innerText = pieceMovement.movementArray[startEnd].pieces.team + ' ' + pieceMovement.movementArray[startEnd].pieces.type;
+            if (pieceMovement.movementArray[startEnd].pieces.stock > 0) {
+                  firstLineComment.insertAdjacentText('beforeend', ' - ' + pieceMovement.movementArray[startEnd].pieces.goods + ": " + pieceMovement.movementArray[startEnd].pieces.stock);
+            }
+            commentary.style.bottom = 0;
+
+            // commentary event handler for goods
+            if(pieceMovement.movementArray.start.pieces.team == gameManagement.turn && pieceMovement.movementArray.start.pieces.stock > 0) {
+                secondLineComment.innerText = 'Select quantity of goods to load';
+                commentary.addEventListener('click', clickGoods);
+            }
+
+            if (pieceMovement.movementArray[startEnd].pieces.populatedSquare) {
+
+                // Claiming of unclaimed resources
+                if (pieceMovement.movementArray[startEnd].pieces.category == 'Resources' && pieceMovement.movementArray[startEnd].pieces.type != 'desert' && pieceMovement.movementArray[startEnd].pieces.team == 'Unclaimed') {
+                    // Check that this resource type is not already held by player
+                    let pieceTotalsTeamPosition = stockDashboard.pieceTotals.findIndex(fI => fI.team == gameManagement.turn);
+                    if(stockDashboard.pieceTotals[pieceTotalsTeamPosition].pieces[pieceMovement.movementArray.start.pieces.type] == 0) {
+                        if (pieceMovement.shipAvailable('crew') == 'crew') {
+                            // TO ADD - Check that ship has not previously landed crew somewhere
+                            secondLineComment.innerText = 'Click ship to land team and claim resource';
+                            startEnd = 'end';
+                            gameBoard.drawActiveTiles();
+                        }
+                    } else {
+                        secondLineComment.innerText = 'You have already claimed your ' + pieceMovement.movementArray[startEnd].pieces.type;
+                    }
+
+                // Loading of a ship
+              } else if (((pieceMovement.movementArray.start.pieces.category == 'Resources' && pieceMovement.movementArray.start.pieces.type != 'desert') || pieceMovement.movementArray.start.pieces.category == 'Settlements') && pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn) {
+                    if (pieceMovement.shipAvailable(pieceMovement.movementArray.start.pieces.goods) == 'compatible') {
+                        if (pieceMovement.movementArray.start.pieces.stock > 0) {
+                            startEnd = 'end';
+                            gameBoard.drawActiveTiles();
+                        } else if (pieceMovement.movementArray.start.pieces.stock == 0) {
+                            secondLineComment.innerText = 'No goods to be loaded';
+                        }
+                    } else if (pieceMovement.shipAvailable(pieceMovement.movementArray.start.pieces.goods) == 'incompatible') {
+                        secondLineComment.innerText = 'Docked ship already carrying different goods';
+                    }
+
+                // Piece movement
+                } else if (pieceMovement.movementArray[startEnd].pieces.team == gameManagement.turn && pieceMovement.movementArray[startEnd].pieces.used == 'unused') {
+                    if (pieceMovement.movementArray[startEnd].pieces.type == 'cargo ship' && (pieceMovement.movementArray[startEnd].pieces.damageStatus == 'good' || pieceMovement.movementArray[startEnd].pieces.damageStatus == 'damaged')) {
+                        secondLineComment.innerText = 'Click any red tile to move';
+                        // If "Start" piece is validated startEnd gate is opened and potential tiles are activated
+                        startEnd = 'end';
+                        if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
+                            pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, 2, true, 'damaged');
+                        } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
+                            pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, maxMove, true, 'good');
+                        }
+                        // Redraw gameboard to show activated tiles
+                        gameBoard.drawActiveTiles();
+                        console.log('within boardMArkNode loop');
+                        console.log(pieceMovement.movementArray);
+                    }
+                }
+
+                // Unloading of a ship
+                if (pieceMovement.movementArray.start.pieces.team == gameManagement.turn && pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.start.pieces.stock > 0) {
+
+                    // Delivery of goods for contract
+                    let depotSearch = pieceMovement.depotAvailable(pieceMovement.movementArray.start.pieces.goods);
+                    if (depotSearch.includes('fort delivery')) {
+                        if (pieceMovement.movementArray.start.pieces.used == 'unused') {
+                            secondLineComment.insertAdjacentText('beforeend',' or deliver goods');
+                        } else {
+                            secondLineComment.innerText = 'Click red tile to deliver goods';
+                        }
+                        startEnd = 'end';
+                        // Redraw gameboard to show activated tiles
+                        gameBoard.drawActiveTiles();
+
+                    // Unloading to own team fort or resource tile
+                    } else if (depotSearch.includes(pieceMovement.movementArray.start.pieces.goods) || depotSearch.includes('fort compatible')) {
+                        if (pieceMovement.movementArray.start.pieces.used == 'unused') {
+                            secondLineComment.insertAdjacentText('beforeend',' or select quantity of goods to unload');
+                        } else {
+                            secondLineComment.innerText = 'Select quantity of goods to unload';
+                        }
+                        startEnd = 'end';
+                        // Redraw gameboard to show activated tiles
+                        gameBoard.drawActiveTiles();
+                    } else if (depotSearch.includes('fort incompatible') && pieceMovement.movementArray.start.pieces.used == 'used') {
+                        secondLineComment.innerText = 'Fort can only hold one goods type';
+                    }
+                }
+            }
+        // Once "start" piece has been selected second click needs to be to an active "end" square
+        // Piece move is then made
+        } else if (startEnd == 'end') {
+            // Removing commentary
+            commentary.style.bottom = '-10%';
+            if (pieceMovement.movementArray.end.activeStatus == 'active') {
+                // Claiming of unclaimed resources
+                if (pieceMovement.movementArray.end.pieces.category == 'Transport' && pieceMovement.movementArray.start.pieces.type != 'desert' && pieceMovement.movementArray.start.pieces.team == 'Unclaimed') {
+                    pieceMovement.deactivateTiles(1);
+                    gameBoard.drawActiveTiles();
+                    // Calculate placement on board of resource tile to be altered
+                    let IDPiece = 'tile' + Number(pieceMovement.movementArray.start.row*1000 + pieceMovement.movementArray.start.col);
+                    document.getElementById(IDPiece).remove();
+                    gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.team = gameManagement.turn;
+                    boardMarkNode.appendChild(gameBoard.createActionTile(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.type, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.team,
+                      'tile' + Number((pieceMovement.movementArray.start.row)*1000 + (pieceMovement.movementArray.start.col)), boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * pieceMovement.movementArray.start.row, boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * pieceMovement.movementArray.start.col, 1, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.direction));
+                    startEnd = 'start';
+
+                // Loading of goods
+                } else if ((pieceMovement.movementArray.start.pieces.category == 'Resources' || pieceMovement.movementArray.start.pieces.category == 'Settlements') && pieceMovement.movementArray.end.pieces.type == 'cargo ship') {
+                    pieceMovement.deactivateTiles(1);
+                    gameBoard.drawActiveTiles();
+                    //loadingStock = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock;
+                    loadingGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
+                    gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= loadingStock;
+                    if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.category == 'Settlements') {
+                        if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock == 0) {
+                            gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods = 'none';
+                        }
+                    }
+                    gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.stock += loadingStock;
+                    gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.goods = loadingGoods;
+                    loadingStock = 0;
 
                 // Delivery of goods for contract
-                let depotSearch = pieceMovement.depotAvailable(pieceMovement.movementArray.start.pieces.goods);
-                if (depotSearch.includes('fort delivery')) {
-                    if (pieceMovement.movementArray.start.pieces.used == 'unused') {
-                        secondLineComment.insertAdjacentText('beforeend',' or deliver goods');
-                    } else {
-                        secondLineComment.innerText = 'Click red tile to deliver goods';
-                    }
-                    startEnd = 'end';
-                    // Redraw gameboard to show activated tiles
+                } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == 'Kingdom' && pieceMovement.movementArray.end.pieces.type == 'fort') {
+                    pieceMovement.deactivateTiles(1);
                     gameBoard.drawActiveTiles();
+                    tradeContracts.discoverPath(pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
+                    tradeContracts.fulfilDelivery();
+                    tradeContracts.drawContracts();
 
                 // Unloading to own team fort or resource tile
-                } else if (depotSearch.includes(pieceMovement.movementArray.start.pieces.goods) || depotSearch.includes('fort compatible')) {
-                    if (pieceMovement.movementArray.start.pieces.used == 'unused') {
-                        secondLineComment.insertAdjacentText('beforeend',' or select quantity of goods to unload');
-                    } else {
-                        secondLineComment.innerText = 'Select quantity of goods to unload';
-                    }
-                    startEnd = 'end';
-                    // Redraw gameboard to show activated tiles
+                } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == gameManagement.turn && (pieceMovement.movementArray.end.pieces.type == 'fort' || pieceMovement.movementArray.end.pieces.category == 'Resources')) {
+                    pieceMovement.deactivateTiles(maxMove);
                     gameBoard.drawActiveTiles();
-                } else if (depotSearch.includes('fort incompatible') && pieceMovement.movementArray.start.pieces.used == 'used') {
-                    secondLineComment.innerText = 'Fort can only hold one goods type';
-                }
-            }
-        }
-    // Once "start" piece has been selected second click needs to be to an active "end" square
-    // Piece move is then made
-    } else if (startEnd == 'end') {
-        // Removing commentary
-        commentary.style.bottom = '-10%';
-        if (pieceMovement.movementArray.end.activeStatus == 'active') {
-            // Claiming of unclaimed resources
-            if (pieceMovement.movementArray.end.pieces.category == 'Transport' && pieceMovement.movementArray.start.pieces.type != 'desert' && pieceMovement.movementArray.start.pieces.team == 'Unclaimed') {
-                pieceMovement.deactivateTiles(1);
-                gameBoard.drawActiveTiles();
-                // Calculate placement on board of resource tile to be altered
-                let IDPiece = 'tile' + Number(pieceMovement.movementArray.start.row*1000 + pieceMovement.movementArray.start.col);
-                document.getElementById(IDPiece).remove();
-                gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.team = gameManagement.turn;
-                boardMarkNode.appendChild(gameBoard.createActionTile(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.type, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.team,
-                  'tile' + Number((pieceMovement.movementArray.start.row)*1000 + (pieceMovement.movementArray.start.col)), boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * pieceMovement.movementArray.start.row, boardSurround + tileBorder/2 + (gridSize + tileBorder * 2) * pieceMovement.movementArray.start.col, 1, gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.direction));
-                startEnd = 'start';
-
-            // Loading of goods
-            } else if ((pieceMovement.movementArray.start.pieces.category == 'Resources' || pieceMovement.movementArray.start.pieces.category == 'Settlements') && pieceMovement.movementArray.end.pieces.type == 'cargo ship') {
-                pieceMovement.deactivateTiles(1);
-                gameBoard.drawActiveTiles();
-                //loadingStock = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock;
-                loadingGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
-                gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= loadingStock;
-                if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.category == 'Settlements') {
+                    //loadingStock = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock;
+                    loadingGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
+                    gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= loadingStock;
                     if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock == 0) {
                         gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods = 'none';
                     }
+                    gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.stock += loadingStock;
+                    gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.goods = loadingGoods;
+                    loadingStock = 0;
+
+                // Piece movement
+                } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship') {
+                    endTurn.removeEventListener('click', nextTurn);
+                    boardMarkNode.removeEventListener('click', boardHandler);
+                    pieceMovement.deactivateTiles(maxMove);
+                    // Redraw active tile layer after deactivation to remove activated tiles
+                    gameBoard.drawActiveTiles();
+                    pieceMovement.shipTransition(gameSpeed);
+
                 }
-                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.stock += loadingStock;
-                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.goods = loadingGoods;
-                loadingStock = 0;
-
-            // Delivery of goods for contract
-            } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == 'Kingdom' && pieceMovement.movementArray.end.pieces.type == 'fort') {
-                pieceMovement.deactivateTiles(1);
-                gameBoard.drawActiveTiles();
-                tradeContracts.discoverPath(pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
-                tradeContracts.fulfilDelivery();
-                tradeContracts.drawContracts();
-
-            // Unloading to own team fort or resource tile
-            } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship' && pieceMovement.movementArray.end.pieces.team == gameManagement.turn && (pieceMovement.movementArray.end.pieces.type == 'fort' || pieceMovement.movementArray.end.pieces.category == 'Resources')) {
+            } else {
+                // Resetting if second click is not valid
                 pieceMovement.deactivateTiles(maxMove);
                 gameBoard.drawActiveTiles();
-                //loadingStock = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock;
-                loadingGoods = gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods;
-                gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock -= loadingStock;
-                if (gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.stock == 0) {
-                    gameBoard.boardArray[pieceMovement.movementArray.start.row][pieceMovement.movementArray.start.col].pieces.goods = 'none';
-                }
-                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.stock += loadingStock;
-                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces.goods = loadingGoods;
-                loadingStock = 0;
 
-            // Piece movement
-            } else if (pieceMovement.movementArray.start.pieces.type == 'cargo ship') {
-                endTurn.removeEventListener('click', nextTurn);
-                boardMarkNode.removeEventListener('click', boardHandler);
-                pieceMovement.deactivateTiles(maxMove);
-                // Redraw active tile layer after deactivation to remove activated tiles
-                gameBoard.drawActiveTiles();
-                pieceMovement.shipTransition(gameSpeed);
+                // Resetting movement array once second click has been made (if invalid)
+                pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
+                startEnd = 'start';
 
+                // Removing commentary goods event handler
+                commentary.removeEventListener('click', clickGoods);
+                clearCommentary();
             }
-        } else {
-            // Resetting if second click is not valid
-            pieceMovement.deactivateTiles(maxMove);
-            gameBoard.drawActiveTiles();
 
-            // Resetting movement array once second click has been made (if invalid)
-            pieceMovement.movementArray = {start: {row: '', col: ''}, end: {row: '', col: ''}};
-            startEnd = 'start';
-
-            // Removing commentary goods event handler
-            commentary.removeEventListener('click', clickGoods);
-            clearCommentary();
+            // Update the stock dashboard
+            stockDashboard.stockTake();
+            stockDashboard.drawStock();
         }
-
-        // Update the stock dashboard
-        stockDashboard.stockTake();
-        stockDashboard.drawStock();
     }
-};
+}
 
 // boardMarkNode is board holder in document
 let boardMarkLeft = boardMarkNode.offsetLeft;

--- a/movement.js
+++ b/movement.js
@@ -270,6 +270,7 @@ let pieceMovement = {
         } else {
             this.movementArray[fromTo].activeStatus = gameBoard.boardArray[this.movementArray[fromTo].row][this.movementArray[fromTo].col].activeStatus;
         }
+        console.log(this.movementArray);
     },
 
     // Method for ship movement and transition


### PR DESCRIPTION
Clicking on the board node but not on the tile area was creating errors as movement.js tried to process moves to invalid tiles (i.e those above row/col or those less than zero). Bug removed by validating chosen tile within required boundaries (>= 0 and < rol, col).