### PR TITLE
Removing trade routes and allocating quadrants to pirate ships

### DIFF
--- a/board.js
+++ b/board.js
@@ -170,19 +170,19 @@ let gameBoard = {
         this.boardArray[boardCenter+1][0].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '90', used: 'unused', damageStatus: 'good', team: 'Blue Team', goods: 'none', stock: 0, production: 0, homeRow: boardCenter+1, homeCol: 0};
 
         // Creation of pirate ships and pirate harbours
-        this.boardArray[4][6] = {xpos: 4, ypos: 6, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: 4, homeCol: 6}};
+        this.boardArray[4][6] = {xpos: 4, ypos: 6, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, ref: 0}};
         //this.boardArray[4][6].terrain = 'sea';
         //this.boardArray[4][6].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[row-7][4] = {xpos: row-7, ypos: 4, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: row-7, homeCol: 4}};
+        this.boardArray[row-7][4] = {xpos: row-7, ypos: 4, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, ref: 1}};
         //this.boardArray[row-7][4].terrain = 'sea';
         //this.boardArray[row-7][4].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[row-5][col-7] = {xpos: row-5, ypos: col-7, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: row-5, homeCol: col-7}};
+        this.boardArray[row-5][col-7] = {xpos: row-5, ypos: col-7, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, ref: 2}};
         //this.boardArray[row-5][col-7].terrain = 'sea';
         //this.boardArray[row-5][col-7].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-45', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
-        this.boardArray[6][col-5] = {xpos: 6, ypos: col-5, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, homeRow: 6, homeCol: col-5}};
+        this.boardArray[6][col-5] = {xpos: 6, ypos: col-5, terrain: 'sea', subTerrain: 'pirateHarbour', activeStatus: 'inactive', pieces: {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0, ref: 3}};
         //this.boardArray[6][col-5].terrain = 'sea';
         //this.boardArray[6][col-5].pieces = {populatedSquare: true, category: 'Transport', type: 'cargo ship', direction: '-135', used: 'unused', damageStatus: 'good', team: 'Pirate', goods: 'none', stock: 0};
 
@@ -1334,7 +1334,11 @@ let gameBoard = {
     // Method to draw a trade route on the board
     // -----------------------------------------
     // Local path is an array of objects of the form {fromRow: 15, fromCol: 4}
-    tradeRoute: function(localPath, localTeam) {
+    tradeRoute: function(localPath, localTeam, localFort, localGoods) {
+
+        let pathGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        tradeRouteLayer.appendChild(pathGroup);
+        pathGroup.id = localGoods + '_' + localFort;
 
         let route = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         route.setAttribute('class', localTeam + ' team_route');
@@ -1353,7 +1357,7 @@ let gameBoard = {
         route.setAttribute('stroke-linejoin', 'round');
         route.setAttribute('stroke-opacity', '0.5');
         route.style.strokeWidth = '3px';
-        tradeRouteLayer.appendChild(route);
+        pathGroup.appendChild(route);
 
         let startCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
         startCircle.setAttribute('class', localTeam + ' team_fill team_route');
@@ -1363,7 +1367,7 @@ let gameBoard = {
         startCircle.style.strokeWidth = '1px';
         startCircle.style.strokeLinecap = 'round';
         startCircle.setAttribute('fill', 'none');
-        tradeRouteLayer.appendChild(startCircle);
+        pathGroup.appendChild(startCircle);
 
         let endCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
         endCircle.setAttribute('class', localTeam + ' team_fill team_route');
@@ -1373,7 +1377,7 @@ let gameBoard = {
         endCircle.style.strokeWidth = '1px';
         endCircle.style.strokeLinecap = 'round';
         //endCircle.setAttribute('fill', 'none');
-        tradeRouteLayer.appendChild(endCircle);
+        pathGroup.appendChild(endCircle);
 
     },
 

--- a/contracts.js
+++ b/contracts.js
@@ -134,20 +134,48 @@ let tradeContracts = {
                 if (this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].team == gameManagement.turn) {
 
                     if(this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].struck == 'active') {
-                        this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].timeRemaining -= 1;
-                        gameBoard.boardArray[this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].resourceRow][this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].resourceCol].pieces.stock -=1;
-
-                        if (this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].timeRemaining == 0) {
-                            this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].struck = 'closed';
+                        if(this.contractObstacle(this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].contractPath) == true) {
+                            IDtradeRoute = resourceManagement.resourcePieces[l].goods + '_' + k;
+                            let closedTradeRoute = document.getElementById(IDtradeRoute);
+                            closedTradeRoute.remove();
+                            this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods] = {created: false, struck: 'unopen', team: 'none', initial: 0, renewal: 0, timeRemaining: 0};
                             this.contractsArray[k].totalActive -=1;
-                            this.contractsArray[k].totalClosed +=1;
+                            this.contractsArray[k].totalUnopen +=1;
+                        } else {
+                            this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].timeRemaining -= 1;
+                            gameBoard.boardArray[this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].resourceRow][this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].resourceCol].pieces.stock -=1;
+
+                            if (this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].timeRemaining == 0) {
+                                this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].struck = 'closed';
+                                this.contractsArray[k].totalActive -=1;
+                                this.contractsArray[k].totalClosed +=1;
+                                console.log(resourceManagement.resourcePieces[l].goods + '_' + k);
+                                IDtradeRoute = resourceManagement.resourcePieces[l].goods + '_' + k;
+                                let closedTradeRoute = document.getElementById(IDtradeRoute);
+                                closedTradeRoute.remove();
+                            }
                         }
                     }
                 }
-
             }
         }
     },
+
+    // Method to check whether obstacles are present to prevent trade being delivered along route
+    // ------------------------------------------------------------------------------------------
+    contractObstacle: function(tradePath) {
+        let obstacle = false;
+        for (var i = 0; i < tradePath.length; i++) {
+            if(gameBoard.boardArray[tradePath[i].fromRow][tradePath[i].fromCol].pieces.team == 'Pirate') {
+                obstacle = true;
+                console.log(tradePath[i], 'Pirate');
+            } else {
+                console.log(tradePath[i], 'clear');
+            }
+        }
+        return obstacle;
+    },
+
 
     // Array of paths for finding trade route
     // --------------------------------------
@@ -239,9 +267,9 @@ let tradeContracts = {
             }
             k += 1;
         }
-        // creates the SVG path for the trade route
+
+        // separates the path for the trade route
         let localPath = this.tradePath[harbour.harbourEndRow][harbour.harbourEndCol].path;
-        gameBoard.tradeRoute(localPath, gameManagement.turn);
 
         // Add path and Resource tile to contract array
         for (var f = 0; f < this.contractsArray.length; f++) {
@@ -253,6 +281,9 @@ let tradeContracts = {
         this.contractsArray[chosenFort].contracts[localGoods].resourceCol = localStartCol;
         this.contractsArray[chosenFort].contracts[localGoods].contractPath = localPath;
         console.log(this.contractsArray[chosenFort]);
+
+        // creates the SVG path for the trade route
+        gameBoard.tradeRoute(localPath, gameManagement.turn, chosenFort, localGoods);
 
     },
 

--- a/gamemanagement.js
+++ b/gamemanagement.js
@@ -10,8 +10,8 @@ let gameManagement = {
     // List of teams
     // -------------
     // Future update: set up based on user inputs for number of players and player names
-    //teamArray: ['Green Team', 'Blue Team', 'Red Team', 'Orange Team'],
     teamArray: ['Green Team', 'Blue Team', 'Red Team', 'Orange Team', 'Pirate'],
+    //teamArray: ['Green Team', 'Blue Team', 'Red Team', 'Orange Team'],
 
     // Current turn
     // ------------
@@ -61,7 +61,7 @@ let gameManagement = {
     // Settings and options
     // --------------------
     optionsArray: [
-                  { variable: 'speed', active: 'fast', options: [{text: 'slow', active: false, constant: 1.5}, {text: 'medium', active: false, constant: 1}, {text: 'fast', active: true, constant: 0.6}] },
+                  { variable: 'speed', active: 'medium', options: [{text: 'slow', active: false, constant: 1.5}, {text: 'medium', active: true, constant: 1}, {text: 'fast', active: false, constant: 0.6}] },
                   { variable: 'dev', options: [{text: 'workflow', active: true}, {text: 'transitions', active: false}] },
                   ],
 

--- a/main.js
+++ b/main.js
@@ -335,7 +335,7 @@ if(workFlow == 1) {
 // Maximum number of iterations for movement and thus maximum number of tiles that can be moved
 // --- movement is also influenced by the movement cost
 // --- once more transport is created this will all need to be built into an array if it desired that different ships move at different speeds
-let maxMove = 5;
+let maxMove = 4;
 
 // Variables for clicked tiles with startEnd indicating the start or end of the move
 let startEnd = 'start';

--- a/movement.js
+++ b/movement.js
@@ -67,7 +67,7 @@ let pieceMovement = {
         //if (displayActive) {
         //    gameBoard.boardArray[localStartRow][localStartCol].activeStatus = 'inactive';
         //}
-        //console.log('completed find path slice', this.findPath.slice(0));
+        console.log('completed find path slice', this.findPath.slice(0));
     },
 
     initialisefindPath: function(localStartRow, localStartCol) {
@@ -355,7 +355,7 @@ let pieceMovement = {
                                 //console.log(chosenPiece);
                                 //console.log(pieceMovement.movementArray);
                                 gameBoard.boardArray[pieceMovement.movementArray['start'].row][pieceMovement.movementArray['start'].col].pieces = {populatedSquare: false, category: '', type: 'no piece', direction: '', used: 'unused', damageStatus: 'good', team: '', goods: 'none', stock: 0};
-                                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces = {populatedSquare: true, category: pieceMovement.movementArray.start.pieces.category, type: pieceMovement.movementArray.start.pieces.type, direction: rotateDirection, used: 'used', damageStatus: pieceMovement.movementArray.start.pieces.damageStatus, team: pieceMovement.movementArray.start.pieces.team, goods: pieceMovement.movementArray.start.pieces.goods, stock: pieceMovement.movementArray.start.pieces.stock, homeRow: pieceMovement.movementArray.start.pieces.homeRow, homeCol: pieceMovement.movementArray.start.pieces.homeCol};
+                                gameBoard.boardArray[pieceMovement.movementArray.end.row][pieceMovement.movementArray.end.col].pieces = {populatedSquare: true, category: pieceMovement.movementArray.start.pieces.category, type: pieceMovement.movementArray.start.pieces.type, direction: rotateDirection, used: 'used', damageStatus: pieceMovement.movementArray.start.pieces.damageStatus, team: pieceMovement.movementArray.start.pieces.team, goods: pieceMovement.movementArray.start.pieces.goods, stock: pieceMovement.movementArray.start.pieces.stock, ref: pieceMovement.movementArray.start.pieces.ref};
 
                                 //Updating piece information
                                 chosenPiece.setAttribute('id', 'tile' + Number(pieceMovement.movementArray.end.row*1000 + pieceMovement.movementArray.end.col));

--- a/pirates.js
+++ b/pirates.js
@@ -2,7 +2,12 @@
 // Pirates movement object - methods for AI of pirateship movement
 let pirates = {
 
-    pirateShips: [],
+    pirateShips: [
+                  {manifest: {ref: 0, homeRow: 4, homeCol: 6, returnRow: 11, returnCol: 11}, start: {row: '', col: ''}, end: {row: '', col: ''}},
+                  {manifest: {ref: 1, homeRow: 24, homeCol: 4, returnRow: 19, returnCol: 11}, start: {row: '', col: ''}, end: {row: '', col: ''}},
+                  {manifest: {ref: 2, homeRow: 26, homeCol: 24, returnRow: 19, returnCol: 19}, start: {row: '', col: ''}, end: {row: '', col: ''}},
+                  {manifest: {ref: 3, homeRow: 6, homeCol: 26, returnRow: 11, returnCol: 19}, start: {row: '', col: ''}, end: {row: '', col: ''}},
+    ],
 
     pirateCount: -1,
 
@@ -16,15 +21,18 @@ let pirates = {
             let pathDistance = 0;
             // Starting tile for pirate ship move taken from array of pirate ships
             pieceMovement.movementArray.start = pirates.pirateShips[pirates.pirateCount].start;
+
             // Tiles activated which also finds path for moves and target information on reachable area
             // true / false allow red boundaries to be highlighted or not
+            let searchRange = 0;
             if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
                 if(workFlow == 1) {console.log('Damaged ship - find paths: '+ (Date.now() - launchTime)); }
-                let searchRange = Math.max(Math.abs(pirates.pirateShips[pirates.pirateCount].start.pieces.homeRow - pirates.pirateShips[pirates.pirateCount].start.row), Math.abs(pirates.pirateShips[pirates.pirateCount].start.pieces.homeCol - pirates.pirateShips[pirates.pirateCount].start.col));
+                searchRange = Math.max(Math.abs(pirates.pirateShips[pirates.pirateCount].manifest.homeRow - pirates.pirateShips[pirates.pirateCount].start.row), Math.abs(pirates.pirateShips[pirates.pirateCount].manifest.homeCol - pirates.pirateShips[pirates.pirateCount].start.col), 2);
                 pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, 2.1, searchRange, false, 'damaged');
             } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
                 if(workFlow == 1) {console.log('Good ship - find paths: '+ (Date.now() - launchTime)); }
-                pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, maxMove, false, 'good');
+                searchRange = Math.max(Math.abs(pirates.pirateShips[pirates.pirateCount].manifest.returnRow - pirates.pirateShips[pirates.pirateCount].start.row), Math.abs(pirates.pirateShips[pirates.pirateCount].manifest.returnCol - pirates.pirateShips[pirates.pirateCount].start.col), maxMove);
+                pieceMovement.activateTiles(pieceMovement.movementArray.start.row, pieceMovement.movementArray.start.col, maxMove, searchRange, false, 'good');
             }
             //console.log('findPath', pieceMovement.findPath);
             // Redraw active tile layer after activation to show activated tiles
@@ -32,9 +40,9 @@ let pirates = {
 
             if (pieceMovement.movementArray.start.pieces.damageStatus == 'damaged') {
                 if(workFlow == 1) {console.log('Damaged ship - decide move: '+ (Date.now() - launchTime)); }
-                lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].start.pieces.homeRow][pirates.pirateShips[pirates.pirateCount].start.pieces.homeCol].path, 0);
-                pirates.pirateShips[pirates.pirateCount].end.row = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].start.pieces.homeRow][pirates.pirateShips[pirates.pirateCount].start.pieces.homeCol].path[lastTile].fromRow;
-                pirates.pirateShips[pirates.pirateCount].end.col = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].start.pieces.homeRow][pirates.pirateShips[pirates.pirateCount].start.pieces.homeCol].path[lastTile].fromCol;
+                lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.homeRow][pirates.pirateShips[pirates.pirateCount].manifest.homeCol].path, 0);
+                pirates.pirateShips[pirates.pirateCount].end.row = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.homeRow][pirates.pirateShips[pirates.pirateCount].manifest.homeCol].path[lastTile].fromRow;
+                pirates.pirateShips[pirates.pirateCount].end.col = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.homeRow][pirates.pirateShips[pirates.pirateCount].manifest.homeCol].path[lastTile].fromCol;
                 pathDistance = 2;
 
             } else if (pieceMovement.movementArray.start.pieces.damageStatus == 'good') {
@@ -44,6 +52,7 @@ let pirates = {
                 pirates.findTarget();
                 pirates.useTelescope();
                 if ((pirates.targetCargo.length > 0) && (pirates.pirateShips[pirates.pirateCount].start.pieces.damageStatus != 'damaged')) {
+                // 1 - Look for cargo ships within wind range
                     //console.log('targetCargo - before', pirates.targetCargo);
                     pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'distance');
                     pirates.targetCargo = pirates.minArray(pirates.targetCargo, 'moveCost');
@@ -58,6 +67,7 @@ let pirates = {
                     //pieceMovement.shipConflict(pirates.pirateShips[pirates.pirateCount].end.row, pirates.pirateShips[pirates.pirateCount].end.col, pirates.targetCargo[0].row, pirates.targetCargo[0].col);
                     pirates.conflictArray = {conflict: true, pirate: {row: pirates.pirateShips[pirates.pirateCount].end.row, col: pirates.pirateShips[pirates.pirateCount].end.col}, ship: {row: pirates.targetCargo[0].row, col: pirates.targetCargo[0].col}};
                 } else if (pirates.targetTelescope.length > 0 && (pirates.pirateShips[pirates.pirateCount].start.pieces.damageStatus != 'damaged')) {
+                // 2 - Search for team cargo ships within telescope range
                     // Finds cargo ships within visual range (localMaxMove) then cuts down array based on minimum distance and move cost
                     //console.log('targetTelescope - before', pirates.targetTelescope);
                     pirates.targetTelescope = pirates.minArray(pirates.targetTelescope, 'distance');
@@ -68,8 +78,12 @@ let pirates = {
                     pirates.pirateShips[pirates.pirateCount].end.row = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromRow;
                     pirates.pirateShips[pirates.pirateCount].end.col = pieceMovement.findPath[pirates.targetTelescope[0].row][pirates.targetTelescope[0].col].path[lastTile].fromCol;
                     //console.log('findLast', pirates.pirateShips[pirates.pirateCount].end.row, pirates.pirateShips[pirates.pirateCount].end.col, 0);
+                } else if (this.outsideRange(this.pirateCount) == true) {
+                    lastTile = pirates.findLastActive(pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.returnRow][pirates.pirateShips[pirates.pirateCount].manifest.returnCol].path, 0);
+                    pirates.pirateShips[pirates.pirateCount].end.row = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.returnRow][pirates.pirateShips[pirates.pirateCount].manifest.returnCol].path[lastTile].fromRow;
+                    pirates.pirateShips[pirates.pirateCount].end.col = pieceMovement.findPath[pirates.pirateShips[pirates.pirateCount].manifest.returnRow][pirates.pirateShips[pirates.pirateCount].manifest.returnCol].path[lastTile].fromCol;
                 } else {
-                    // If no ships in active range or visual range moves to maximum distance at minimum wind cost
+                // 3- If no ships in active range or visual range moves to maximum distance at minimum wind cost
                     if(workFlow == 1) {console.log('Finds max distance move at minimum cost: ' + (Date.now() - launchTime)); }
                     pirates.maxPathDistance();
                     pirates.minCostTiles = pirates.minArray(pirates.maxDistanceTiles, 'moveCost');
@@ -116,7 +130,10 @@ let pirates = {
             stockDashboard.drawStock();
 
             // Resets pirate ship array once all moves made
-            pirates.pirateShips = [];
+            for (var i = 0; i < pirates.pirateShips.length; i++) {
+                this.pirateShips[i].start = {row: '', col: ''};
+                this.pirateShips[i].end = {row: '', col: ''};
+            }
             pirates.pirateCount = -1;
             endTurn.addEventListener('click', nextTurn);
             boardMarkNode.addEventListener('click', boardHandler);
@@ -132,7 +149,8 @@ let pirates = {
         for (var i = 0; i < gameBoard.boardArray.length; i++) {
             for (var j = 0; j < gameBoard.boardArray[i].length; j++) {
                 if((gameBoard.boardArray[i][j].pieces.team == 'Pirate') && (gameBoard.boardArray[i][j].pieces.type = 'cargo ship')) {
-                    this.pirateShips.push({start: {row: + i, col: + j, pieces: gameBoard.boardArray[i][j].pieces}, end: {row: + i, col: + j}});
+                    this.pirateShips[gameBoard.boardArray[i][j].pieces.ref].start = {row: + i, col: + j, pieces: gameBoard.boardArray[i][j].pieces};
+                    this.pirateShips[gameBoard.boardArray[i][j].pieces.ref].end = {row: + i, col: + j};
                 }
             }
         }
@@ -154,8 +172,8 @@ let pirates = {
     findTarget: function() {
         if(workFlow == 1) {console.log('Find cargo ship as target: ' + (Date.now() - launchTime)); }
         this.targetCargo = [];
-        for (var i = 0; i < col; i++) {
-            for (var j = 0; j < row; j++) {
+        for (var i = 0; i < row; i++) {
+            for (var j = 0; j < col; j++) {
                 if ((pieceMovement.findPath[i][j].target == 'cargo ship') && (gameBoard.boardArray[i][j].pieces.team != 'Pirate') && (gameBoard.boardArray[i][j].pieces.damageStatus != 'damaged') && (pieceMovement.findPath[i][j].activeStatus == 'active')) {
                     this.targetCargo.push({row: + i, col: + j, distance: + pieceMovement.findPath[i][j].distance, moveCost: + pieceMovement.findPath[i][j].moveCost});
                 }
@@ -169,14 +187,13 @@ let pirates = {
     useTelescope: function() {
         if(workFlow == 1) {console.log('Use telescope: ' + (Date.now() - launchTime)); }
         this.targetTelescope = [];
-        for (var i = 0; i < col; i++) {
-            for (var j = 0; j < row; j++) {
+        for (var i = Math.max(pieceMovement.movementArray.start.row - maxMove, 0); i < Math.min(pieceMovement.movementArray.start.row + maxMove + 1, row); i++) {
+            for (var j = Math.max(pieceMovement.movementArray.start.col - maxMove, 0); j < Math.min(pieceMovement.movementArray.start.col + maxMove + 1, col); j++) {
                 if ((pieceMovement.findPath[i][j].target == 'cargo ship') && (gameBoard.boardArray[i][j].pieces.team != 'Pirate') && (gameBoard.boardArray[i][j].pieces.damageStatus != 'damaged') && (gameBoard.boardArray[i][j].subTerrain != 'harbour')) {
                     this.targetTelescope.push({row: + i, col: + j, distance: + pieceMovement.findPath[i][j].distance, moveCost: + pieceMovement.findPath[i][j].moveCost});
                 }
             }
         }
-
     },
 
     // Method to find last active tile on a path
@@ -234,6 +251,8 @@ let pirates = {
         return resultArray;
     },
 
+    // Finds safe harbours from pirate ships
+    // -------------------------------------
     safeHarbour: function() {
         if(workFlow == 1) {console.log('Determine safe harbours: ' + (Date.now() - launchTime)); }
         for (var i = 0; i < row; i++) {
@@ -252,6 +271,22 @@ let pirates = {
                     }
                 }
             }
+        }
+    },
+
+    // Determines if pirate ships have strayed too far from their range
+    // ----------------------------------------------------------------
+    outsideRange: function(shipNumber) {
+        if (pirates.pirateShips[shipNumber].manifest.returnRow < 15 && pirates.pirateShips[shipNumber].start.row > 15) {
+            return true;
+        } else if (pirates.pirateShips[shipNumber].manifest.returnRow > 15 && pirates.pirateShips[shipNumber].start.row < 15) {
+            return true;
+        } else if (pirates.pirateShips[shipNumber].manifest.returnCol < 15 && pirates.pirateShips[shipNumber].start.col > 15) {
+            return true;
+        } else if (pirates.pirateShips[shipNumber].manifest.returnCol > 15 && pirates.pirateShips[shipNumber].start.col < 15) {
+            return true;
+        } else {
+            return false;
         }
     },
 


### PR DESCRIPTION
Removing trade routes:
Pirate ships can block trade routes causing the contract to be cancelled.
* Method to check whether obstacles (currently pirate ships) are present to prevent trade being delivered along each trade route for a player at the start of their turn.
* Contracts game logic updated for removal of an existing trade route.
* Elements of trade route SVGs combined into a single group for ease of removal of SVG.

Allocating quadrants to pirate ships:
Pirate ships were grouping at the edges of the board, due to all following the same wind direction. To prevent this pirate ships have been allocated their own quadrants and a specific tile to which they head back if they stray to far from home. 
* Creation of a permanent pirateShips array with information on where pirate ships should return to if they stray to far from their base quadrant.
* Method to determine if pirate ships have strayed too far from their range.
* Addition of ref key to boardArray to link pirate ship board info to pirateShips array.
* Reworking of search logic within tile activation and telescope use so that path to return tile is always available.