### PR TITLE
Each team is restricted to only one contract per island

### DIFF
--- a/contracts.js
+++ b/contracts.js
@@ -85,19 +85,38 @@ let tradeContracts = {
 
     // Method to check possible delivery to fulfil open contract
     // ---------------------------------------------------------
-    checkDelivery : function(locali, localj, searchType, localStock) {
+    checkDelivery : function(locali, localj, searchType, localStock, localTeam) {
+        let delivery = false;
+
         // Determines which fort is being delivered to
         let chosenFort = -1;
-        let delivery = false;
-        for (var k = 0; k < this.contractsArray.length; k++) {
+        for (var k = 0; k < this.contractsArray.length; k+=1) {
             if(this.contractsArray[k].row == locali && this.contractsArray[k].col == localj) {
                 chosenFort = k;
             }
         }
 
+        // Determines whether a team already has a contract with that island (only one contract per island is allowed)
+        let checkTeam = false;
+        for (var contractGood in this.contractsArray[chosenFort].contracts) {
+            if(this.contractsArray[chosenFort].contracts[contractGood].team == localTeam) {
+                  checkTeam = true;
+            }
+        }
+
         // Determines whether ship cargo meets criteria for delivery
-        if(this.contractsArray[chosenFort].contracts[searchType].struck == 'open' && this.contractsArray[chosenFort].contracts[searchType].initial <= localStock) {
-            delivery = true;
+        if(this.contractsArray[chosenFort].contracts[searchType].struck == 'open') {
+            if(this.contractsArray[chosenFort].contracts[searchType].initial <= localStock) {
+                if(checkTeam == false ) {
+                    delivery = true;
+                } else {
+                    secondLineComment.innerText = localTeam + ' already has a contract with this island.';
+                }
+            } else {
+                secondLineComment.innerText = 'Insufficient goods to comeplete contract.';
+            }
+        } else {
+            secondLineComment.innerText = 'No open contract for these goods.';
         }
 
         return delivery;
@@ -181,9 +200,9 @@ let tradeContracts = {
         for (var i = 0; i < tradePath.length; i++) {
             if(gameBoard.boardArray[tradePath[i].fromRow][tradePath[i].fromCol].pieces.team == 'Pirate') {
                 obstacle = true;
-                console.log(tradePath[i], 'Pirate');
+                //console.log(tradePath[i], 'Pirate');
             } else {
-                console.log(tradePath[i], 'clear');
+                //console.log(tradePath[i], 'clear');
             }
         }
         return obstacle;
@@ -499,17 +518,17 @@ let tradeContracts = {
 
                             // Icon added
                             if (this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck == 'open') {
-                                console.log('open');
+                                //console.log('open');
                                 let divTypeIcon = gameBoard.createActionTile(0, 0, resourceManagement.resourcePieces[j].type, 'Unclaimed', 'dash_' + resourceManagement.resourcePieces[j].type, 2, 0, 1.5, 0);
                                 divType.appendChild(divTypeIcon);
                                 divForText.innerHTML = this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck;
                             } else if (this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck == 'active') {
-                                console.log('active', this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck);
+                                //console.log('active', this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck);
                                 let divTypeIcon = gameBoard.createActionTile(0, 0, resourceManagement.resourcePieces[j].type, this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].team, 'dash_' + resourceManagement.resourcePieces[j].type, 2, 0, 1.5, 0);
                                 divType.appendChild(divTypeIcon);
                                 divForText.innerHTML = 'active';
                             } else if (this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].struck == 'closed') {
-                                console.log('closed');
+                                //console.log('closed');
                                 let divTypeIcon = gameBoard.createActionTile(0, 0, resourceManagement.resourcePieces[j].type, this.contractsArray[i].contracts[resourceManagement.resourcePieces[j].goods].team, 'dash_' + resourceManagement.resourcePieces[j].type, 2, 0, 1.5, 0);
                                 divType.appendChild(divTypeIcon);
                                 divForText.innerHTML = 'closed';

--- a/main.js
+++ b/main.js
@@ -557,7 +557,7 @@ function boardHandler(event) {
 
                 // Delivery of goods for contract
               } else if (pieceMovement.movementArray.start.pieces.category == 'Transport' && pieceMovement.movementArray.end.pieces.team == 'Kingdom' && pieceMovement.movementArray.end.pieces.type == 'fort') {
-                    pieceMovement.deactivateTiles(1);
+                    pieceMovement.deactivateTiles(maxMove);
                     gameBoard.drawActiveTiles();
                     tradeContracts.discoverPath(pieceMovement.movementArray.end.row, pieceMovement.movementArray.end.col, pieceMovement.movementArray.start.pieces.goods);
                     tradeContracts.fulfilDelivery();

--- a/movement.js
+++ b/movement.js
@@ -517,13 +517,12 @@ let pieceMovement = {
             if(this.movementArray.start.row+i >=0 && this.movementArray.start.row+i <row) {
                 for (var j = -searchDistance; j < searchDistance + 1; j++) {
                     if(this.movementArray.start.col+j >=0 && this.movementArray.start.col+j <col) {
-                        // Reduces seacrh to exclude diagonals
+                        // Reduces search to exclude diagonals
                         if((i == 0 || j == 0) && i != j) {
                             // Checks if tile meets criteria
                             //console.log('here', gameBoard.boardArray[this.movementArray.start.row+i][this.movementArray.start.col+j].pieces.type, gameBoard.boardArray[this.movementArray.start.row+i][this.movementArray.start.col+j].pieces.team);
                             if (gameBoard.boardArray[this.movementArray.start.row+i][this.movementArray.start.col+j].pieces.type == 'fort' && gameBoard.boardArray[this.movementArray.start.row+i][this.movementArray.start.col+j].pieces.team == 'Kingdom') {
-                                //console.log('kingdom, fort');
-                                if(tradeContracts.checkDelivery(this.movementArray.start.row+i, this.movementArray.start.col+j, searchType, gameBoard.boardArray[this.movementArray.start.row][this.movementArray.start.col].pieces.stock) == true) {
+                                if(tradeContracts.checkDelivery(this.movementArray.start.row+i, this.movementArray.start.col+j, searchType, gameBoard.boardArray[this.movementArray.start.row][this.movementArray.start.col].pieces.stock, gameBoard.boardArray[this.movementArray.start.row][this.movementArray.start.col].pieces.team) == true) {
                                     //console.log('delivery');
                                     result.push('fort delivery');
                                     gameBoard.boardArray[this.movementArray.start.row+i][this.movementArray.start.col+j].activeStatus = 'active';


### PR DESCRIPTION
To prevent a player simply repeating contracts with the nearest island to their base, a restriction to one contract per island is imposed for each player. 
[The aim will thus be to complete contracts with each of the four islands. An alternative game ending will be developed for when a player has closed contracts with all islands]

contract.js
* checkDelivery updated to determines whether a team already has a contract with that island 
* checkDelivery also changed to give different commentary depending on which delivery criteria are met / failed

movement.js
* Call to checkDelivery now also passes team name for team check

main.js
* small bug removed where tiles were not all being deactivated when a ship delivered goods for a contract prior to moving (the deactivation was previously set to one square - sufficient for contract delivery but not if the ship also has activated tiles for movement)
