### PR TITLE
Add mark to harbour to show team has completed contract with that island

### DIFF
--- a/board.js
+++ b/board.js
@@ -1652,7 +1652,6 @@ let gameBoard = {
     // -----------------------------------------
     // Local path is an array of objects of the form {fromRow: 15, fromCol: 4}
     tradeRoute: function(localPath, localTeam, localFort, localGoods) {
-
         let pathGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         tradeRouteLayer.appendChild(pathGroup);
         pathGroup.id = localGoods + '_' + localFort;
@@ -1696,6 +1695,23 @@ let gameBoard = {
         //endCircle.setAttribute('fill', 'none');
         pathGroup.appendChild(endCircle);
 
+    },
+
+    // Method to add mark to harbour to show team has completed contract with that island
+    // ----------------------------------------------------------------------------------
+    closedRouteMark: function(localRow, localCol, localTeam, localFort) {
+        let islandTeamHarbour = {'Green Team': [1,0], 'Blue Team': [0,-1], 'Red Team': [-1,0], 'Orange Team': [0,1]}
+
+        let closedMark = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        closedMark.id = localTeam + '_' + localFort;
+        closedMark.setAttribute('class', localTeam + ' team_route');
+        closedMark.setAttribute('cx', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * (localCol + islandTeamHarbour[localTeam][1])));
+        closedMark.setAttribute('cy', (boardSurround + tileBorder + gridSize/2 + (gridSize + tileBorder * 2) * (localRow + islandTeamHarbour[localTeam][0])));
+        closedMark.setAttribute('r', '7');
+        closedMark.setAttribute('fill', 'none');
+        closedMark.style.strokeWidth = '2px';
+        closedMark.style.strokeLinecap = 'round';
+        tradeRouteLayer.appendChild(closedMark);
     },
 
     // Method to add moon and time to the board

--- a/contracts.js
+++ b/contracts.js
@@ -26,11 +26,11 @@ let tradeContracts = {
             let teamContracts = {};
             for (var j = 0; j < resourceManagement.resourcePieces.length; j++) {
                 // TESTING teamContracts[resourceManagement.resourcePieces[j].goods] = {created: false, struck: 'unopen', team: 'none', initial: 0, renewal: 0, timeRemaining: 0};
-                teamContracts[resourceManagement.resourcePieces[j].goods] = {created: true, struck: 'open', team: 'none', initial: 3, renewal: 1, timeRemaining: 8};
+                teamContracts[resourceManagement.resourcePieces[j].goods] = {created: true, struck: 'open', team: 'none', initial: 3, renewal: 1, timeRemaining: 1};
             }
             this.contractsArray[i].contracts = teamContracts;
         }
-        console.log(this.contractsArray);
+        //console.log(this.contractsArray);
     },
 
     // Method to randomly generate new contract
@@ -181,10 +181,11 @@ let tradeContracts = {
                                 this.contractsArray[k].contracts[resourceManagement.resourcePieces[l].goods].struck = 'closed';
                                 this.contractsArray[k].totalActive -=1;
                                 this.contractsArray[k].totalClosed +=1;
-                                console.log(resourceManagement.resourcePieces[l].goods + '_' + k);
                                 IDtradeRoute = resourceManagement.resourcePieces[l].goods + '_' + k;
                                 let closedTradeRoute = document.getElementById(IDtradeRoute);
                                 closedTradeRoute.remove();
+                                // creates the SVG marker for the closed trade route
+                                gameBoard.closedRouteMark(this.contractsArray[k].row, this.contractsArray[k].col, gameManagement.turn, k);
                             }
                         }
                     }
@@ -225,8 +226,8 @@ let tradeContracts = {
         }
     },
 
-    // Method to find path for ship to move
-    // ------------------------------------
+    // Method to find path for trade route
+    // -----------------------------------
     discoverPath: function(localEndRow, localEndCol, localGoods) {
         // Finds current team resource in boardArray for start of path
         let localStartRow = 0;

--- a/scoring.js
+++ b/scoring.js
@@ -58,7 +58,6 @@ let gameScore = {
             let countExplored = [0, 0, 0, 0];
             let scoreSubCategories = Object.keys(this.scoreArray[0].Exploring);
             scoreSubCategories.splice(6, 3);
-            console.log(scoreSubCategories);
             for (var i = 0; i < scoreSubCategories.length; i++) {
                 // Loop of each team to count number of previously found resources
                 for (var j = 0; j < this.scoreArray.length; j++) {


### PR DESCRIPTION
Now that a team can only have one contract with an island, it is useful to add a team colour marker next to the island once a contract is complete. This makes a quick reference on the board to illustrate that the team already has completed a contract with that island and will remind them not to initiate another contract with the same island. 

board.js
* Added the closedRouteMark method which adds a mark (SVG) in the appropriate harbour to show team has completed contract with that island (the harbour marks align with the position of the team settlements).

contracts.js
* Simply added the call to the closedRouteMark method
(other minor changes temporary for working in test environment)