### PR TITLE
Computer opponent - improving pirate avoidance

### DIFF
--- a/movement.js
+++ b/movement.js
@@ -115,6 +115,8 @@ let pieceMovement = {
                                 //console.log('row: ' + (localStartRow+i) + ' col: ' + (localStartCol+j) + ' prior cost: ' + localCumulMoveCost + ' new cost: ' + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection))
                                 if (localDamagedStatus == 0) {
                                     tileCumulMoveCost = localCumulMoveCost + 1;
+                                } else if (localCumulMoveCost > localMaxMove) {
+                                    tileCumulMoveCost = localCumulMoveCost + 1;
                                 } else {
                                     tileCumulMoveCost = localCumulMoveCost + this.moveCost(localStartRow, localStartCol ,localStartRow+i, localStartCol+j, needleDirection);
                                 }
@@ -244,7 +246,7 @@ let pieceMovement = {
                                 if(j + l >=0 && j + l <col) {
                                     // Mark the distance from the ship (plain number of tiles not wind-based moveCost)
                                     if(gameBoard.boardArray[i+k][j+l].terrain == 'sea' && gameBoard.boardArray[i+k][j+l].subterrain != 'harbour') {
-                                        this.findPath[i+k][j+l].pirateRange.type.push(Math.max(Math.abs(k), Math.abs(l))-maxMovePirate-1);
+                                        this.findPath[i+k][j+l].pirateRange.type.push(maxMovePirate - Math.max(Math.abs(k), Math.abs(l))+1);
                                     }
                                 }
                             }


### PR DESCRIPTION
Ranking of moves includes avoidance of pirate ships. Previously this was based simply on the number of tiles distance to the pirate ships. This commit updates pirate avoidance move ranking penalties to include the probability of capture and a (currently hard-coded) divisor to reflect the number of moves penalty.